### PR TITLE
docs: update decompilation workflow for Windsurf 1.13.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Windsurf uses gRPC for communication with its server, and it's not a public API.
 
 ## Problem 3: Understanding the protocol
 
-With ports and protos, we can finally send messages to the server. Go to the network tab, observe what chat.js sends, decode protobufs to get an idea of what to send and where. Write a client and that's it.
+With ports and protos, we can finally send messages to the server. Go to the network tab, observe what workbench.desktop.main.js sends, decode protobufs to get an idea of what to send and where. Write a client and that's it.
 
 Wrap that shit in a REST server with proper queueing (Windsurf does this UI-side instead of at gRPC level), and now you can:
 - Start new conversations

--- a/decompile/.gitignore
+++ b/decompile/.gitignore
@@ -1,1 +1,3 @@
 chat.js
+workbench.desktop.main.js
+workbench.desktop.main.protos.js

--- a/decompile/DECOMPILE.md
+++ b/decompile/DECOMPILE.md
@@ -1,14 +1,32 @@
 # Decompiling Windsurf protos
 
-Working as of 2025-10-03
+Working as of 2026-01-30 (Windsurf 1.13.14 / Extension 1.48.2)
 
-1. Get `chat.js` using VSCode dev tools from the Windsurf cascade panel
-2. Place it in this folder as `chat.js`
-3. Format it (takes fucking long but necessary)
-4. Run `decompile_protos.js`
-5. It will fail with something like `document is not defined on line <LINE>`
-6. Go to `chat.js` and remove everything starting from that line
-7. Run `find_services.js` - it generates something like `module.exports = { random obfuscated names }`
-8. Copy the output and place it at the end of `chat.js`
-9. Run `decompile_protos.js` again - should work and produce protos in `protos` folder
-10. No need to do it every time, i have commited protos to the repo, but if something stopped working you know what to do
+## New workflow (current builds: `workbench.desktop.main.js`)
+
+1. Get `workbench.desktop.main.js` from your installed Windsurf build.
+2. Place it in this folder as `workbench.desktop.main.js`.
+3. Run `strip_bundle.js` to extract just the proto/service definitions:
+
+    `pnpm exec node decompile/strip_bundle.js`
+
+    This generates `workbench.desktop.main.protos.js`.
+4. Run `decompile_protos.js`:
+
+    `pnpm exec node decompile/decompile_protos.js`
+
+    It should produce protos in the `protos/` folder.
+
+## Legacy workflow (older builds: `chat.js`)
+
+1. Get `chat.js` using VSCode dev tools from the Windsurf cascade panel.
+2. Place it in this folder as `chat.js`.
+3. Format it.
+4. Run `decompile_protos.js`.
+5. It will fail with something like `document is not defined on line <LINE>`.
+6. Go to `chat.js` and remove everything starting from that line.
+7. Run `find_services.js` (it prints something like `module.exports = { ... }`).
+8. Copy the output and place it at the end of `chat.js`.
+9. Run `decompile_protos.js` again. It should produce protos in the `protos/` folder.
+
+No need to do it every time; protos are committed to the repo. Use this if something stopped working.

--- a/decompile/decompile_protos.js
+++ b/decompile/decompile_protos.js
@@ -1,5 +1,36 @@
-const protos = require("./chat.js");
 const fs = require("fs");
+const path = require("path");
+
+const protosBundlePath = path.join(__dirname, "workbench.desktop.main.protos.js");
+const workbenchBundlePath = path.join(__dirname, "workbench.desktop.main.js");
+const legacyBundlePath = path.join(__dirname, "chat.js");
+
+let bundlePath;
+if (fs.existsSync(protosBundlePath)) {
+  bundlePath = protosBundlePath;
+} else if (fs.existsSync(legacyBundlePath)) {
+  bundlePath = legacyBundlePath;
+} else if (fs.existsSync(workbenchBundlePath)) {
+  throw new Error(
+    [
+      "Missing decompile/workbench.desktop.main.protos.js.",
+      "Found decompile/workbench.desktop.main.js, but decompile_protos.js will not load it.",
+      "Run: pnpm exec node decompile/strip_bundle.js",
+      "Then: pnpm exec node decompile/decompile_protos.js",
+    ].join("\n")
+  );
+} else {
+  throw new Error(
+    [
+      "Missing decompile/workbench.desktop.main.protos.js.",
+      "Expected one of:",
+      "- decompile/workbench.desktop.main.protos.js",
+      "- decompile/chat.js",
+    ].join("\n")
+  );
+}
+
+const protos = require(bundlePath);
 
 const enums = {};
 const services = {};

--- a/decompile/strip_bundle.js
+++ b/decompile/strip_bundle.js
@@ -1,0 +1,577 @@
+const fs = require("fs");
+const path = require("path");
+
+const inputPath =
+  process.argv[2] ?? path.join(__dirname, "workbench.desktop.main.js");
+const outputPath =
+  process.argv[3] ?? path.join(__dirname, "workbench.desktop.main.protos.js");
+
+const source = fs.readFileSync(inputPath, "utf8");
+
+const isIdentChar = (ch) => /[A-Za-z0-9_$]/.test(ch);
+
+const skipStringOrComment = (s, i) => {
+  const ch = s[i];
+
+  if (ch === "'" || ch === '"' || ch === "`") {
+    const quote = ch;
+    i++;
+    while (i < s.length) {
+      const c = s[i];
+      if (c === "\\") {
+        i += 2;
+        continue;
+      }
+
+      if (quote === "`" && c === "$" && s[i + 1] === "{") {
+        i += 2;
+        let depth = 1;
+        while (i < s.length && depth > 0) {
+          const inner = s[i];
+
+          if (
+            inner === "'" ||
+            inner === '"' ||
+            inner === "`" ||
+            inner === "/"
+          ) {
+            const next = skipStringOrComment(s, i);
+            if (next > i) {
+              i = next;
+              continue;
+            }
+          }
+
+          if (inner === "{") {
+            depth++;
+          } else if (inner === "}") {
+            depth--;
+          }
+
+          i++;
+        }
+        continue;
+      }
+
+      if (c === quote) {
+        i++;
+        break;
+      }
+      i++;
+    }
+    return i;
+  }
+
+  if (ch === "/") {
+    const next = s[i + 1];
+    if (next === "/") {
+      i += 2;
+      while (i < s.length && s[i] !== "\n") {
+        i++;
+      }
+      return i;
+    }
+    if (next === "*") {
+      i += 2;
+      while (i < s.length) {
+        if (s[i] === "*" && s[i + 1] === "/") {
+          i += 2;
+          break;
+        }
+        i++;
+      }
+      return i;
+    }
+  }
+
+  return i;
+};
+
+const findMatchingBrace = (s, openIndex) => {
+  let i = openIndex;
+  if (s[i] !== "{") {
+    throw new Error("expected {");
+  }
+
+  let depth = 0;
+  while (i < s.length) {
+    const ch = s[i];
+
+    if (ch === "'" || ch === '"' || ch === "`" || ch === "/") {
+      const next = skipStringOrComment(s, i);
+      if (next > i) {
+        i = next;
+        continue;
+      }
+    }
+
+    if (ch === "{") {
+      depth++;
+    } else if (ch === "}") {
+      depth--;
+      if (depth === 0) {
+        return i;
+      }
+    }
+
+    i++;
+  }
+
+  throw new Error("unmatched brace");
+};
+
+const extractAssignmentBlock = (startIndex) => {
+  let i = startIndex;
+
+  while (i > 0 && /\s/.test(source[i - 1])) {
+    i--;
+  }
+
+  let identEnd = i;
+  let identStart = identEnd;
+  while (identStart > 0 && isIdentChar(source[identStart - 1])) {
+    identStart--;
+  }
+
+  const varName = source.slice(identStart, identEnd);
+
+  let j = startIndex;
+  while (j < source.length && source[j] !== "=") {
+    j++;
+  }
+  if (source[j] !== "=") {
+    throw new Error("expected =");
+  }
+
+  j++;
+  while (j < source.length && /\s/.test(source[j])) {
+    j++;
+  }
+
+  if (source.slice(j, j + 5) === "class") {
+    const openBrace = source.indexOf("{", j);
+    const closeBrace = findMatchingBrace(source, openBrace);
+
+    let end = closeBrace + 1;
+    while (end < source.length && /\s/.test(source[end])) {
+      end++;
+    }
+    if (source[end] === ",") {
+      end++;
+    }
+
+    const rhs = source.slice(j, closeBrace + 1);
+    return { varName, rhs, end };
+  }
+
+  if (source[j] === "{") {
+    const closeBrace = findMatchingBrace(source, j);
+
+    let end = closeBrace + 1;
+    while (end < source.length && /\s/.test(source[end])) {
+      end++;
+    }
+    if (source[end] === ",") {
+      end++;
+    }
+
+    const rhs = source.slice(j, closeBrace + 1);
+    return { varName, rhs, end };
+  }
+
+  return null;
+};
+
+const extracted = {
+  messageAssignments: [],
+  enumCalls: [],
+  serviceAssignments: [],
+  aliasAssignments: [],
+};
+
+const seenVars = new Set();
+const seenAliasNames = new Set();
+
+const pushVar = (arr, name, rhs) => {
+  if (!name || seenVars.has(name)) {
+    return;
+  }
+  seenVars.add(name);
+  arr.push({ name, rhs });
+};
+
+const pushAlias = (name, target) => {
+  if (!name || seenAliasNames.has(name)) {
+    return;
+  }
+  seenAliasNames.add(name);
+  extracted.aliasAssignments.push({ name, target });
+};
+
+for (let i = 0; i < source.length; i++) {
+  const ch = source[i];
+  if (ch === "'" || ch === '"' || ch === "`" || ch === "/") {
+    const next = skipStringOrComment(source, i);
+    if (next > i) {
+      i = next - 1;
+      continue;
+    }
+  }
+
+  if (ch === "=") {
+    let t = i + 1;
+    while (t < source.length && /\s/.test(source[t])) {
+      t++;
+    }
+
+    if (
+      source.slice(t, t + 5) === "class" &&
+      source.slice(t, t + 400).includes("extends Message")
+    ) {
+      let identEnd = i;
+      let b = i - 1;
+      while (b >= 0 && /\s/.test(source[b])) {
+        b--;
+      }
+      identEnd = b + 1;
+      let identStart = identEnd;
+      while (identStart > 0 && isIdentChar(source[identStart - 1])) {
+        identStart--;
+      }
+
+      const name = source.slice(identStart, identEnd);
+      if (name && /[A-Za-z_$]/.test(name[0])) {
+        const block = extractAssignmentBlock(identEnd);
+        if (block) {
+          pushVar(extracted.messageAssignments, block.varName, block.rhs);
+          i = block.end - 1;
+          continue;
+        }
+      }
+    }
+
+    if (/[A-Za-z_$]/.test(source[t])) {
+      let u = t + 1;
+      while (u < source.length && isIdentChar(source[u])) {
+        u++;
+      }
+      const target = source.slice(t, u);
+
+      if (target.startsWith("$")) {
+        let identEnd = i;
+        let b = i - 1;
+        while (b >= 0 && /\s/.test(source[b])) {
+          b--;
+        }
+        identEnd = b + 1;
+        let identStart = identEnd;
+        while (identStart > 0 && isIdentChar(source[identStart - 1])) {
+          identStart--;
+        }
+
+        const name = source.slice(identStart, identEnd);
+        if (name && /^[A-Z][A-Za-z0-9_]*$/.test(name)) {
+          pushAlias(name, target);
+        }
+      }
+    }
+  }
+
+  if (
+    source.startsWith("const ", i) ||
+    source.startsWith("let ", i) ||
+    source.startsWith("var ", i)
+  ) {
+    const keywordLen = source.startsWith("const ", i)
+      ? 5
+      : source.startsWith("let ", i)
+        ? 3
+        : 3;
+
+    let j = i + keywordLen;
+    while (j < source.length && /\s/.test(source[j])) {
+      j++;
+    }
+
+    if (source[j] !== "{" && source[j] !== "[") {
+      const identStart = j;
+      if (/[A-Za-z_$]/.test(source[identStart])) {
+        j++;
+        while (j < source.length && isIdentChar(source[j])) {
+          j++;
+        }
+
+        const name = source.slice(identStart, j);
+        let k = j;
+        while (k < source.length && /\s/.test(source[k])) {
+          k++;
+        }
+
+        if (source[k] === "=") {
+          let t = k + 1;
+          while (t < source.length && /\s/.test(source[t])) {
+            t++;
+          }
+
+          if (
+            source.slice(t, t + 5) === "class" &&
+            source.slice(t, t + 400).includes("extends Message")
+          ) {
+            const block = extractAssignmentBlock(j);
+            if (block) {
+              pushVar(extracted.messageAssignments, block.varName, block.rhs);
+              i = block.end - 1;
+              continue;
+            }
+          }
+
+          if (/[A-Za-z_$]/.test(source[t])) {
+            let u = t + 1;
+            while (u < source.length && isIdentChar(source[u])) {
+              u++;
+            }
+            const target = source.slice(t, u);
+            pushAlias(name, target);
+          }
+        }
+      }
+    }
+  }
+
+  if (ch === "$") {
+    let j = i + 1;
+    while (j < source.length && isIdentChar(source[j])) {
+      j++;
+    }
+
+    const name = source.slice(i, j);
+    let k = j;
+    while (k < source.length && /\s/.test(source[k])) {
+      k++;
+    }
+
+    if (source[k] === "=") {
+      let t = k + 1;
+      while (t < source.length && /\s/.test(source[t])) {
+        t++;
+      }
+
+      if (
+        source.slice(t, t + 5) === "class" &&
+        source.slice(t, t + 80).includes("extends Message")
+      ) {
+        const block = extractAssignmentBlock(j);
+        if (block) {
+          pushVar(extracted.messageAssignments, block.varName, block.rhs);
+          i = block.end - 1;
+          continue;
+        }
+      }
+
+      if (
+        source[t] === "{" &&
+        source.slice(t, t + 200).includes("typeName") &&
+        source.slice(t, t + 200).includes('"exa')
+      ) {
+        const block = extractAssignmentBlock(j);
+        if (block) {
+          pushVar(extracted.serviceAssignments, block.varName, block.rhs);
+          i = block.end - 1;
+          continue;
+        }
+      }
+    }
+  }
+
+  if (source.startsWith("proto3.util.setEnumType(", i)) {
+    const callStart = i;
+    let j = i;
+    while (j < source.length && source[j] !== "(") {
+      j++;
+    }
+
+    let parenDepth = 0;
+    while (j < source.length) {
+      const c = source[j];
+
+      if (c === "'" || c === '"' || c === "`" || c === "/") {
+        const next = skipStringOrComment(source, j);
+        if (next > j) {
+          j = next;
+          continue;
+        }
+      }
+
+      if (c === "(") {
+        parenDepth++;
+      } else if (c === ")") {
+        parenDepth--;
+        if (parenDepth === 0) {
+          j++;
+          break;
+        }
+      }
+
+      j++;
+    }
+
+    while (j < source.length && /\s/.test(source[j])) {
+      j++;
+    }
+    if (source[j] === ";") {
+      j++;
+    }
+
+    const stmt = source.slice(callStart, j);
+    if (stmt.includes('"exa')) {
+      extracted.enumCalls.push(stmt);
+    }
+
+    i = j - 1;
+  }
+}
+
+const serviceExportNames = extracted.serviceAssignments.map((s) => s.name);
+
+const enumVarNames = Array.from(
+  new Set(
+    extracted.enumCalls
+      .map((stmt) => {
+        const m = stmt.match(
+          /proto3\.util\.setEnumType\(\s*([A-Za-z_$][A-Za-z0-9_$]*)/
+        );
+        return m?.[1];
+      })
+      .filter(Boolean)
+  )
+);
+
+const extractedMessageVarNames = new Set(
+  extracted.messageAssignments.map((m) => m.name)
+);
+const extractedEnumVarNames = new Set(enumVarNames);
+
+const filteredAliasAssignments = extracted.aliasAssignments.filter(({ name, target }) => {
+  if (!target || typeof target !== "string") {
+    return false;
+  }
+
+  const looksLikeTypeName =
+    typeof name === "string" &&
+    /^[A-Z][A-Za-z0-9_]*$/.test(name) &&
+    (/[a-z]/.test(name) || name.length > 2);
+
+  if (!looksLikeTypeName) {
+    return false;
+  }
+
+  return extractedMessageVarNames.has(target) || extractedEnumVarNames.has(target);
+});
+
+const declaredNames = new Set([
+  ...extracted.messageAssignments.map((m) => m.name),
+  ...filteredAliasAssignments.map((a) => a.name),
+  ...extracted.serviceAssignments.map((s) => s.name),
+]);
+
+const out = [];
+out.push(`
+class Message {
+  constructor() {}
+  fromBinary() { return this; }
+  fromJson() { return this; }
+  fromJsonString() { return this; }
+}
+
+const proto3 = {
+  getEnumType: (t) => t,
+  getMessageType: (t) => t,
+  util: {
+    initPartial: () => {},
+    newFieldList: (fn) => ({
+      list: () => fn().map((f) => ({ repeated: !!f.repeated, ...f })),
+    }),
+    equals: () => false,
+    setEnumType: (enumObj, typeName, values) => {
+      enumObj.typeName = typeName;
+      enumObj.values = values;
+      return enumObj;
+    },
+  },
+};
+`);
+
+if (!declaredNames.has("MethodKind") && !enumVarNames.includes("MethodKind")) {
+  out.push(`
+const MethodKind = { Unary: 0, ClientStreaming: 1, ServerStreaming: 2, BiDiStreaming: 3 };
+`);
+}
+
+for (const { name, rhs } of extracted.messageAssignments) {
+  out.push(`const ${name} = ${rhs};`);
+}
+
+out.push("");
+
+const googleWellKnownMessages = [
+  ["Timestamp", "google.protobuf.Timestamp"],
+  ["Duration", "google.protobuf.Duration"],
+  ["Empty", "google.protobuf.Empty"],
+];
+
+for (const [varName, typeName] of googleWellKnownMessages) {
+  if (declaredNames.has(varName)) {
+    out.push(
+      `if (typeof ${varName}.typeName !== "string") ${varName}.typeName = "${typeName}";`
+    );
+    out.push(
+      `if (typeof ${varName}.fields?.list !== "function") ${varName}.fields = { list: () => [] };`
+    );
+  }
+}
+
+out.push("");
+
+for (const { name, target } of filteredAliasAssignments) {
+  out.push(`const ${name} = ${target};`);
+}
+
+out.push("");
+
+for (const name of enumVarNames) {
+  if (!declaredNames.has(name)) {
+    out.push(`const ${name} = {};`);
+  }
+}
+
+out.push("");
+
+for (const stmt of extracted.enumCalls) {
+  out.push(stmt);
+}
+
+out.push("");
+
+for (const { name, rhs } of extracted.serviceAssignments) {
+  out.push(`const ${name} = ${rhs};`);
+}
+
+out.push("");
+out.push(`module.exports = { ${serviceExportNames.join(", ")} };`);
+out.push("");
+
+fs.writeFileSync(outputPath, out.join("\n"));
+
+console.log(
+  JSON.stringify(
+    {
+      inputPath,
+      outputPath,
+      messages: extracted.messageAssignments.length,
+      enums: extracted.enumCalls.length,
+      services: extracted.serviceAssignments.length,
+    },
+    null,
+    2
+  )
+);

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+onlyBuiltDependencies:
+  - '@bufbuild/buf'
+  - esbuild

--- a/protos/exa.auto_cascade_common_pb.proto
+++ b/protos/exa.auto_cascade_common_pb.proto
@@ -5,12 +5,6 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/empty.proto";
 
 package exa.auto_cascade_common_pb;
-message GitRepoInfo {  string repo_name = 1;
-  string branch = 2;
-  string commit = 3;
-  string pr_url = 4;
-}
-
 message GithubPullRequestInfo {  string url = 1;
   string owner = 2;
   string repo = 3;

--- a/protos/exa.bug_checker_pb.proto
+++ b/protos/exa.bug_checker_pb.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/empty.proto";
+
+package exa.bug_checker_pb;
+message Fix {  string old_str = 1;
+  string new_str = 2;
+}
+
+message Bug {  string id = 1;
+  string file = 2;
+  int32 start = 3;
+  int32 end = 4;
+  string title = 5;
+  string description = 6;
+  string severity = 7;
+  string resolution = 8;
+  double confidence = 9;
+  repeated string categories = 10;
+  exa.bug_checker_pb.Fix fix = 11;
+}
+

--- a/protos/exa.cascade_plugins_pb.proto
+++ b/protos/exa.cascade_plugins_pb.proto
@@ -14,6 +14,7 @@ message CascadePluginCommandVariable {  string name = 1;
   string title = 2;
   string description = 3;
   string link = 4;
+  string type = 5;
 }
 
 message CascadePluginCommand {  exa.cascade_plugins_pb.CascadePluginCommandTemplate template = 1;

--- a/protos/exa.chat_pb.proto
+++ b/protos/exa.chat_pb.proto
@@ -7,12 +7,19 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/empty.proto";
 
 package exa.chat_pb;
+message ComputerUseToolConfig {  int32 display_width_px = 1;
+  int32 display_height_px = 2;
+  int32 display_number = 3;
+}
+
 message ChatToolDefinition {  string name = 1;
   string description = 2;
   string json_schema_string = 3;
   bool strict = 4;
   repeated string attribution_field_names = 5;
   string server_name = 6;
+  bool read_only_hint = 7;
+  exa.chat_pb.ComputerUseToolConfig computer_use_config = 8;
 }
 
 message PromptCacheOptions {  exa.chat_pb.CacheControlType type = 1;
@@ -34,10 +41,40 @@ message ChatMessagePrompt {  string message_id = 1;
   repeated exa.codeium_common_pb.PromptAnnotationRange prompt_annotation_ranges = 14;
   string output_id = 15;
   string thinking_id = 16;
+  bytes gemini_thought_signature = 17;
+  string signature_type = 18;
 }
 
 message ChatToolChoice {  string option_name = 1;
   string tool_name = 2;
+}
+
+message DeepWikiSymbolRange {  int64 start_line = 1;
+  int64 start_column = 2;
+  int64 end_line = 3;
+  int64 end_column = 4;
+}
+
+message DeepWikiHoverContext {  string symbol_name = 1;
+  string symbol_uri = 2;
+  exa.chat_pb.DeepWikiSymbolRange symbol_range = 3;
+  exa.chat_pb.DeepWikiSymbolType symbol_type = 4;
+  string hover_text = 5;
+  google.protobuf.Timestamp timestamp = 6;
+}
+
+message ParameterInfo {  string label = 1;
+  string documentation = 2;
+}
+
+message FunctionCallInfo {  string signature_label = 1;
+  int32 active_parameter = 2;
+  int32 parameter_count = 3;
+  repeated exa.chat_pb.ParameterInfo parameters = 4;
+}
+
+message DeepWikiContext {  exa.chat_pb.DeepWikiHoverContext enclosing_hover_context = 1;
+  exa.chat_pb.FunctionCallInfo function_call_info = 2;
 }
 
 message IntentGeneric {  string text = 1;
@@ -164,7 +201,8 @@ message ChatMetrics {  uint64 response_stream_latency_ms = 1;
   exa.codeium_common_pb.CodeContextItem last_active_code_context_item = 12;
   uint64 num_indexed_files = 13;
   uint64 num_indexed_code_context_items = 14;
-  exa.codeium_common_pb.Model model = 15;
+  exa.codeium_common_pb.Model model_deprecated = 15;
+  string model_uid = 17;
 }
 
 message ChatMessageAction {  exa.chat_pb.ChatMessageActionGeneric generic = 1;
@@ -247,7 +285,7 @@ message GetDeepWikiRequest {  exa.codeium_common_pb.Metadata metadata = 1;
 }
 
 enum CacheControlType {  CACHE_CONTROL_TYPE_UNSPECIFIED = 0;  CACHE_CONTROL_TYPE_EPHEMERAL = 1;}
+enum DeepWikiSymbolType {  DEEP_WIKI_SYMBOL_TYPE_UNSPECIFIED = 0;  DEEP_WIKI_SYMBOL_TYPE_FILE = 1;  DEEP_WIKI_SYMBOL_TYPE_MODULE = 2;  DEEP_WIKI_SYMBOL_TYPE_NAMESPACE = 3;  DEEP_WIKI_SYMBOL_TYPE_PACKAGE = 4;  DEEP_WIKI_SYMBOL_TYPE_CLASS = 5;  DEEP_WIKI_SYMBOL_TYPE_METHOD = 6;  DEEP_WIKI_SYMBOL_TYPE_PROPERTY = 7;  DEEP_WIKI_SYMBOL_TYPE_FIELD = 8;  DEEP_WIKI_SYMBOL_TYPE_CONSTRUCTOR = 9;  DEEP_WIKI_SYMBOL_TYPE_ENUM = 10;  DEEP_WIKI_SYMBOL_TYPE_INTERFACE = 11;  DEEP_WIKI_SYMBOL_TYPE_FUNCTION = 12;  DEEP_WIKI_SYMBOL_TYPE_VARIABLE = 13;  DEEP_WIKI_SYMBOL_TYPE_CONSTANT = 14;  DEEP_WIKI_SYMBOL_TYPE_STRING = 15;  DEEP_WIKI_SYMBOL_TYPE_NUMBER = 16;  DEEP_WIKI_SYMBOL_TYPE_BOOLEAN = 17;  DEEP_WIKI_SYMBOL_TYPE_ARRAY = 18;  DEEP_WIKI_SYMBOL_TYPE_OBJECT = 19;  DEEP_WIKI_SYMBOL_TYPE_KEY = 20;  DEEP_WIKI_SYMBOL_TYPE_NULL = 21;  DEEP_WIKI_SYMBOL_TYPE_ENUM_MEMBER = 22;  DEEP_WIKI_SYMBOL_TYPE_STRUCT = 23;  DEEP_WIKI_SYMBOL_TYPE_EVENT = 24;  DEEP_WIKI_SYMBOL_TYPE_OPERATOR = 25;  DEEP_WIKI_SYMBOL_TYPE_TYPE_PARAMETER = 26;}
 enum ChatIntentType {  CHAT_INTENT_UNSPECIFIED = 0;  CHAT_INTENT_GENERIC = 1;  CHAT_INTENT_FUNCTION_EXPLAIN = 2;  CHAT_INTENT_FUNCTION_DOCSTRING = 3;  CHAT_INTENT_FUNCTION_REFACTOR = 4;  CHAT_INTENT_CODE_BLOCK_EXPLAIN = 5;  CHAT_INTENT_CODE_BLOCK_REFACTOR = 6;  CHAT_INTENT_FUNCTION_UNIT_TESTS = 7;  CHAT_INTENT_PROBLEM_EXPLAIN = 8;  CHAT_INTENT_GENERATE_CODE = 9;  CHAT_INTENT_CLASS_EXPLAIN = 10;  CHAT_INTENT_SEARCH = 11;  CHAT_INTENT_FAST_APPLY = 12;}
 enum DeepWikiRequestType {  DEEP_WIKI_REQUEST_TYPE_UNSPECIFIED = 0;  DEEP_WIKI_REQUEST_TYPE_SUMMARY = 1;  DEEP_WIKI_REQUEST_TYPE_ARTICLE = 2;}
-enum DeepWikiSymbolType {  DEEP_WIKI_SYMBOL_TYPE_UNSPECIFIED = 0;  DEEP_WIKI_SYMBOL_TYPE_FILE = 1;  DEEP_WIKI_SYMBOL_TYPE_MODULE = 2;  DEEP_WIKI_SYMBOL_TYPE_NAMESPACE = 3;  DEEP_WIKI_SYMBOL_TYPE_PACKAGE = 4;  DEEP_WIKI_SYMBOL_TYPE_CLASS = 5;  DEEP_WIKI_SYMBOL_TYPE_METHOD = 6;  DEEP_WIKI_SYMBOL_TYPE_PROPERTY = 7;  DEEP_WIKI_SYMBOL_TYPE_FIELD = 8;  DEEP_WIKI_SYMBOL_TYPE_CONSTRUCTOR = 9;  DEEP_WIKI_SYMBOL_TYPE_ENUM = 10;  DEEP_WIKI_SYMBOL_TYPE_INTERFACE = 11;  DEEP_WIKI_SYMBOL_TYPE_FUNCTION = 12;  DEEP_WIKI_SYMBOL_TYPE_VARIABLE = 13;  DEEP_WIKI_SYMBOL_TYPE_CONSTANT = 14;  DEEP_WIKI_SYMBOL_TYPE_STRING = 15;  DEEP_WIKI_SYMBOL_TYPE_NUMBER = 16;  DEEP_WIKI_SYMBOL_TYPE_BOOLEAN = 17;  DEEP_WIKI_SYMBOL_TYPE_ARRAY = 18;  DEEP_WIKI_SYMBOL_TYPE_OBJECT = 19;  DEEP_WIKI_SYMBOL_TYPE_KEY = 20;  DEEP_WIKI_SYMBOL_TYPE_NULL = 21;  DEEP_WIKI_SYMBOL_TYPE_ENUM_MEMBER = 22;  DEEP_WIKI_SYMBOL_TYPE_STRUCT = 23;  DEEP_WIKI_SYMBOL_TYPE_EVENT = 24;  DEEP_WIKI_SYMBOL_TYPE_OPERATOR = 25;  DEEP_WIKI_SYMBOL_TYPE_TYPE_PARAMETER = 26;}
 enum ChatFeedbackType {  FEEDBACK_TYPE_UNSPECIFIED = 0;  FEEDBACK_TYPE_ACCEPT = 1;  FEEDBACK_TYPE_REJECT = 2;  FEEDBACK_TYPE_COPIED = 3;  FEEDBACK_TYPE_ACCEPT_DIFF = 4;  FEEDBACK_TYPE_REJECT_DIFF = 5;  FEEDBACK_TYPE_APPLY_DIFF = 6;  FEEDBACK_TYPE_INSERT_AT_CURSOR = 7;}

--- a/protos/exa.codeium_common_pb.proto
+++ b/protos/exa.codeium_common_pb.proto
@@ -5,24 +5,97 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/empty.proto";
 
 package exa.codeium_common_pb;
-message PathScopeItem {  string absolute_path_migrate_me_to_uri = 1;
-  string absolute_uri = 5;
-  map<string, string> workspace_relative_paths_migrate_me_to_workspace_uris = 2;
-  map<string, string> workspace_uris_to_relative_paths = 6;
-  uint32 num_files = 3;
-  uint64 num_bytes = 4;
+message Metadata {  string ide_name = 1;
+  string ide_version = 7;
+  string ide_type = 28;
+  string extension_name = 12;
+  string extension_version = 2;
+  string api_key = 3;
+  string locale = 4;
+  string os = 5;
+  string hardware = 8;
+  bool disable_telemetry = 6;
+  string session_id = 10;
+  google.protobuf.Timestamp ls_timestamp = 16;
+  uint64 request_id = 9;
+  string source_address = 11;
+  string user_agent = 13;
+  string url = 14;
+  exa.codeium_common_pb.AuthSource auth_source = 15;
+  string extension_path = 17;
+  string user_id = 20;
+  string user_jwt = 21;
+  string force_team_id = 22;
+  string device_fingerprint = 24;
+  string trigger_id = 25;
+  string plan_name = 26;
+  string id = 27;
+  string impersonate_tier = 29;
 }
 
-message GitRepoInfo {  string name = 1;
-  string owner = 2;
-  string repo_name = 5;
-  string commit = 3;
-  string version_alias = 4;
-  exa.codeium_common_pb.ScmProvider scm_provider = 6;
-  string base_git_url = 7;
+message DocumentPosition {  uint64 row = 1;
+  uint64 col = 2;
 }
 
-message RepositoryScopeItem {  exa.codeium_common_pb.GitRepoInfo repo_info = 1;
+message Range {  uint64 start_offset = 1;
+  uint64 end_offset = 2;
+  exa.codeium_common_pb.DocumentPosition start_position = 3;
+  exa.codeium_common_pb.DocumentPosition end_position = 4;
+}
+
+message Document {  string absolute_path_migrate_me_to_uri = 1;
+  string absolute_uri = 12;
+  string relative_path_migrate_me_to_workspace_uri = 2;
+  string workspace_uri = 13;
+  string text = 3;
+  string editor_language = 4;
+  exa.codeium_common_pb.Language language = 5;
+  uint64 cursor_offset = 6;
+  exa.codeium_common_pb.DocumentPosition cursor_position = 8;
+  string line_ending = 7;
+  exa.codeium_common_pb.Range visible_range = 9;
+  bool is_cutoff_start = 10;
+  bool is_cutoff_end = 11;
+  int32 lines_cutoff_start = 14;
+  int32 lines_cutoff_end = 15;
+  google.protobuf.Timestamp timestamp = 16;
+  bool is_dirty = 17;
+  bool is_notebook = 19;
+  google.protobuf.Timestamp last_access_time = 21;
+  repeated exa.codeium_common_pb.Range selections = 22;
+  uint64 hash = 23;
+}
+
+message EditorOptions {  uint64 tab_size = 1;
+  bool insert_spaces = 2;
+  bool disable_autocomplete_in_comments = 3;
+}
+
+message ChatToolCall {  string id = 1;
+  string name = 2;
+  string arguments_json = 3;
+  string invalid_json_str = 4;
+  string invalid_json_err = 5;
+}
+
+message Completion {  string completion_id = 1;
+  string request_uid = 17;
+  string text = 2;
+  string stop = 4;
+  double score = 5;
+  repeated uint64 tokens = 6;
+  repeated string decoded_tokens = 7;
+  repeated double probabilities = 8;
+  repeated double adjusted_probabilities = 9;
+  repeated double logprobs = 16;
+  uint64 generated_length = 10;
+  exa.codeium_common_pb.StopReason stop_reason = 12;
+  repeated exa.codeium_common_pb.FilterReason filter_reasons = 13;
+  string original_text = 14;
+  repeated exa.codeium_common_pb.ChatToolCall tool_calls = 15;
+}
+
+message MockResponseData {  repeated exa.codeium_common_pb.Completion completions = 1;
 }
 
 message WorkspacePath {  string workspace_migrate_me_to_uri = 1;
@@ -35,6 +108,15 @@ message WordCount {  map<string, int64> word_count_map = 1;
 
 message SnippetWithWordCount {  string snippet = 1;
   map<string, exa.codeium_common_pb.WordCount> word_count_by_splitter = 2;
+}
+
+message GitRepoInfo {  string name = 1;
+  string owner = 2;
+  string repo_name = 5;
+  string commit = 3;
+  string version_alias = 4;
+  exa.codeium_common_pb.ScmProvider scm_provider = 6;
+  string base_git_url = 7;
 }
 
 message CodeContextItem {  string absolute_path_migrate_me_to_uri = 1;
@@ -51,6 +133,244 @@ message CodeContextItem {  string absolute_path_migrate_me_to_uri = 1;
   map<string, exa.codeium_common_pb.SnippetWithWordCount> snippet_by_type = 11;
   exa.codeium_common_pb.GitRepoInfo repo_info = 14;
   bytes file_content_hash = 15;
+}
+
+message ExperimentWithVariant {  exa.codeium_common_pb.ExperimentKey key = 1;
+  string key_string = 5;
+  bool disabled = 6;
+  string string = 2;
+  string json = 3;
+  string csv = 4;
+  exa.codeium_common_pb.ExperimentSource source = 7;
+}
+
+message ExperimentConfig {  repeated exa.codeium_common_pb.ExperimentWithVariant experiments = 6;
+  repeated exa.codeium_common_pb.ExperimentKey force_enable_experiments = 1;
+  repeated exa.codeium_common_pb.ExperimentKey force_disable_experiments = 2;
+  repeated exa.codeium_common_pb.ExperimentWithVariant force_enable_experiments_with_variants = 3;
+  repeated string force_enable_experiment_strings = 4;
+  repeated string force_disable_experiment_strings = 5;
+  bool dev_mode = 7;
+}
+
+message CompletionConfiguration {  uint64 num_completions = 1;
+  uint64 max_tokens = 2;
+  uint64 max_newlines = 3;
+  double min_log_probability = 4;
+  double temperature = 5;
+  double first_temperature = 6;
+  uint64 top_k = 7;
+  double top_p = 8;
+  repeated string stop_patterns = 9;
+  uint64 seed = 10;
+  double fim_eot_prob_threshold = 11;
+  bool use_fim_eot_threshold = 12;
+  bool do_not_score_stop_tokens = 13;
+  bool sqrt_len_normalized_log_prob_score = 14;
+  bool last_message_is_partial = 15;
+  bool return_logprob = 16;
+  string service_tier = 17;
+}
+
+message PromptElementRange {  exa.codeium_common_pb.PromptElementKind kind = 1;
+  uint64 byte_offset_start = 2;
+  uint64 byte_offset_end = 3;
+  uint64 token_offset_start = 4;
+  uint64 token_offset_end = 5;
+}
+
+message PromptElementKindInfo {  exa.codeium_common_pb.PromptElementKind kind = 1;
+  exa.codeium_common_pb.ExperimentKey experiment_key = 2;
+  bool enabled = 3;
+  uint64 num_considered = 4;
+  uint64 num_included = 5;
+}
+
+message PromptStageLatency {  string name = 1;
+  uint64 latency_ms = 2;
+}
+
+message Repository {  string computed_name = 1;
+  string git_origin_url = 2;
+  string git_upstream_url = 3;
+  string reported_name = 4;
+  string model_name = 5;
+  string submodule_url = 6;
+  string submodule_path = 7;
+}
+
+message PromptAnnotationRange {  exa.codeium_common_pb.PromptAnnotationKind kind = 1;
+  uint64 byte_offset_start = 2;
+  uint64 byte_offset_end = 3;
+  string suffix = 4;
+}
+
+message CompletionsRequest {  exa.codeium_common_pb.CompletionConfiguration configuration = 1;
+  string prompt = 2;
+  string context_prompt = 21;
+  string uid = 25;
+  repeated exa.codeium_common_pb.PromptElementRange prompt_element_ranges = 8;
+  repeated exa.codeium_common_pb.PromptElementKindInfo prompt_element_kind_infos = 9;
+  uint64 prompt_latency_ms = 11;
+  repeated exa.codeium_common_pb.PromptStageLatency prompt_stage_latencies = 12;
+  uint64 num_tokenized_bytes = 20;
+  string editor_language = 3;
+  exa.codeium_common_pb.Language language = 4;
+  string absolute_path_uri_for_telemetry = 5;
+  string relative_path_for_telemetry = 6;
+  string workspace_uri_for_telemetry = 13;
+  string experiment_features_json = 7;
+  string experiment_variant_json = 19;
+  exa.codeium_common_pb.Model model = 10;
+  bool has_line_suffix = 14;
+  bool should_inline_fim = 15;
+  exa.codeium_common_pb.Repository repository = 16;
+  string model_tag = 17;
+  repeated string experiment_tags = 18;
+  string eval_suffix = 22;
+  repeated exa.codeium_common_pb.PromptAnnotationRange prompt_annotation_ranges = 23;
+  bool supports_packed_streaming_completion_maps = 24;
+}
+
+message ErrorTrace {  string error_id = 1;
+  int64 timestamp_unix_ms = 2;
+  string stacktrace = 3;
+  bool recovered = 4;
+}
+
+message Status {  exa.codeium_common_pb.StatusLevel level = 1;
+  string message = 2;
+}
+
+message ModelOrAlias {  exa.codeium_common_pb.Model model = 1;
+  exa.codeium_common_pb.ModelAlias alias = 2;
+  string model_uid = 3;
+}
+
+message PromoStatus {  bool is_active = 1;
+  google.protobuf.Timestamp end_date = 2;
+  string label = 3;
+}
+
+message FastStatus {  bool is_active = 1;
+  string tooltip = 2;
+}
+
+message ModelFeatures {  bool supports_context_tokens = 2;
+  bool requires_instruct_tags = 3;
+  bool requires_fim_context = 4;
+  bool requires_context_snippet_prefix = 5;
+  bool requires_context_relevance_tags = 6;
+  bool requires_llama3_tokens = 7;
+  bool zero_shot_capable = 8;
+  bool requires_autocomplete_as_command = 9;
+  bool supports_cursor_aware_supercomplete = 10;
+  bool supports_images = 11;
+  bool supports_image_captions = 20;
+  bool supports_tool_calls = 12;
+  bool supports_parallel_tool_calls = 21;
+  bool supports_cumulative_context = 13;
+  bool tab_jump_print_line_range = 14;
+  bool supports_thinking = 15;
+  bool interleave_thinking = 24;
+  bool preserve_thinking = 25;
+  bool supports_estimate_token_counter = 17;
+  bool add_cursor_to_find_replace_target = 18;
+  bool supports_tab_jump_use_whole_document = 19;
+  bool requires_supercomplete_clean = 22;
+  bool tab_route_to_modal = 23;
+  bool supports_rejection_context = 26;
+}
+
+message ModelInfo {  exa.codeium_common_pb.Model model_id = 1;
+  string model_uid = 17;
+  bool is_internal = 2;
+  exa.codeium_common_pb.ModelType model_type = 3;
+  int32 max_tokens = 4;
+  string tokenizer_type = 5;
+  exa.codeium_common_pb.ModelFeatures model_features = 6;
+  exa.codeium_common_pb.APIProvider api_provider = 7;
+  string model_name = 8;
+  bool supports_context = 9;
+  int32 embed_dim = 10;
+  string base_url = 11;
+  string chat_model_name = 12;
+  int32 max_output_tokens = 13;
+  exa.codeium_common_pb.PromptTemplaterType prompt_templater_type = 14;
+  exa.codeium_common_pb.ToolFormatterType tool_formatter_type = 15;
+  string inference_server_url = 18;
+  exa.codeium_common_pb.ArenaTier arena_tier = 19;
+  repeated string harness_uids = 20;
+}
+
+message ClientModelConfig {  string label = 1;
+  exa.codeium_common_pb.ModelOrAlias model_or_alias = 2;
+  string model_uid = 22;
+  float credit_multiplier = 3;
+  exa.codeium_common_pb.ModelPricingType pricing_type = 13;
+  bool disabled = 4;
+  bool supports_images = 5;
+  bool supports_legacy = 6;
+  bool is_premium = 7;
+  string beta_warning_message = 8;
+  bool is_beta = 9;
+  exa.codeium_common_pb.ModelProvider provider = 10;
+  bool is_recommended = 11;
+  repeated exa.codeium_common_pb.TeamsTier allowed_tiers = 12;
+  exa.codeium_common_pb.APIProvider api_provider = 14;
+  bool is_new = 15;
+  bool partial_rollout = 16;
+  float rollout_fraction = 17;
+  int32 max_tokens = 18;
+  exa.codeium_common_pb.PromoStatus promo_status = 19;
+  bool is_capacity_limited = 20;
+  exa.codeium_common_pb.FastStatus fast_status = 21;
+  exa.codeium_common_pb.ModelInfo model_info = 23;
+  exa.codeium_common_pb.ModelCostTier model_cost_tier = 24;
+  exa.codeium_common_pb.ArenaTier arena_tier = 25;
+}
+
+message ClientModelGroup {  string group_name = 1;
+  repeated string model_labels = 2;
+}
+
+message ClientModelSort {  string name = 1;
+  repeated exa.codeium_common_pb.ClientModelGroup groups = 2;
+}
+
+message DefaultOverrideModelConfig {  exa.codeium_common_pb.ModelOrAlias model_or_alias_deprecated = 1;
+  string model_uid = 3;
+  string version_id = 2;
+}
+
+message ExternalModel {  bool is_internal = 1;
+  exa.codeium_common_pb.Model model_id = 2;
+  string model_name = 3;
+  string base_url = 4;
+  string api_key = 5;
+  string access_key = 6;
+  string secret_access_key = 7;
+  string region = 8;
+  string project_id = 9;
+  uint32 id = 10;
+  int32 max_completion_tokens = 11;
+  int32 max_input_tokens = 12;
+}
+
+message Event {  exa.codeium_common_pb.EventType event_type = 1;
+  string event_json = 2;
+  int64 timestamp_unix_ms = 3;
+}
+
+message PathScopeItem {  string absolute_path_migrate_me_to_uri = 1;
+  string absolute_uri = 5;
+  map<string, string> workspace_relative_paths_migrate_me_to_workspace_uris = 2;
+  map<string, string> workspace_uris_to_relative_paths = 6;
+  uint32 num_files = 3;
+  uint64 num_bytes = 4;
+}
+
+message RepositoryScopeItem {  exa.codeium_common_pb.GitRepoInfo repo_info = 1;
 }
 
 message ContextSubrange {  exa.codeium_common_pb.ContextSnippetType snippet_type = 1;
@@ -164,6 +484,63 @@ message GithubPullRequestItem {  string url = 1;
   string number = 4;
 }
 
+message CodeMapScopeItem {  string title = 1;
+  string content = 2;
+  string description = 3;
+  string location = 4;
+}
+
+message McpPromptScopeItem {  string server_name = 1;
+  string prompt_name = 2;
+  map<string, string> arguments = 3;
+  string resolved_content = 4;
+}
+
+message SkillScopeItem {  string skill_name = 1;
+  string description = 2;
+  string uri = 3;
+  int32 resource_count = 4;
+  string base_dir = 5;
+  string content = 6;
+}
+
+message PlanFileScopeItem {  string plan_path = 1;
+  string title = 2;
+  string description = 3;
+  bool request_implementation = 4;
+}
+
+message GitCommitData {  string sha = 1;
+  string short_sha = 2;
+  string subject = 3;
+  string author = 4;
+  google.protobuf.Timestamp timestamp = 5;
+  int32 insertions = 6;
+  int32 deletions = 7;
+}
+
+message GitDiffData {  string branch_name = 1;
+  string base_branch = 2;
+  string merge_base_sha = 3;
+  int32 files_changed = 4;
+  int32 insertions = 5;
+  int32 deletions = 6;
+  string branch_head_sha = 7;
+}
+
+message GitWorkingChangesData {  int32 staged_count = 1;
+  int32 unstaged_count = 2;
+  int32 untracked_count = 3;
+}
+
+message GitScopeItem {  string repo_root_uri = 1;
+  string repo_display_name = 6;
+  exa.codeium_common_pb.GitCommitData commit = 2;
+  exa.codeium_common_pb.GitDiffData diff = 3;
+  exa.codeium_common_pb.GitWorkingChangesData working_changes = 4;
+  string formatted_content = 5;
+}
+
 message ContextScopeItem {  exa.codeium_common_pb.PathScopeItem file = 1;
   exa.codeium_common_pb.PathScopeItem directory = 2;
   exa.codeium_common_pb.RepositoryScopeItem repository = 3;
@@ -189,74 +566,23 @@ message ContextScopeItem {  exa.codeium_common_pb.PathScopeItem file = 1;
   exa.codeium_common_pb.UserActivityScopeItem user_activity = 24;
   exa.codeium_common_pb.TerminalScopeItem terminal = 25;
   exa.codeium_common_pb.GithubPullRequestItem github_pull_request = 26;
+  exa.codeium_common_pb.CodeMapScopeItem code_map = 27;
+  exa.codeium_common_pb.McpPromptScopeItem mcp_prompt = 28;
+  exa.codeium_common_pb.SkillScopeItem skill = 29;
+  exa.codeium_common_pb.PlanFileScopeItem plan_file = 30;
+  exa.codeium_common_pb.GitScopeItem git = 31;
 }
 
-message TextOrScopeItem {  string text = 1;
-  exa.codeium_common_pb.ContextScopeItem item = 2;
+message ContextScope {  repeated exa.codeium_common_pb.ContextScopeItem items = 1;
 }
 
-message ImageData {  string base64_data = 1;
-  string mime_type = 2;
-  string caption = 3;
+message ActionPointer {  string cortex_plan_id = 1;
+  string code_plan_id = 2;
+  int32 action_index = 3;
 }
 
-message Metadata {  string ide_name = 1;
-  string ide_version = 7;
-  string ide_type = 28;
-  string extension_name = 12;
-  string extension_version = 2;
-  string api_key = 3;
-  string locale = 4;
-  string os = 5;
-  string hardware = 8;
-  bool disable_telemetry = 6;
-  string session_id = 10;
-  google.protobuf.Timestamp ls_timestamp = 16;
-  uint64 request_id = 9;
-  string source_address = 11;
-  string user_agent = 13;
-  string url = 14;
-  exa.codeium_common_pb.AuthSource auth_source = 15;
-  string extension_path = 17;
-  string user_id = 20;
-  string user_jwt = 21;
-  string force_team_id = 22;
-  string device_fingerprint = 24;
-  string trigger_id = 25;
-  string plan_name = 26;
-  string id = 27;
-  string impersonate_tier = 29;
-}
-
-message TerminalShellCommandHeader {  exa.codeium_common_pb.Metadata metadata = 7;
-  string terminal_id = 1;
-  uint32 shell_pid = 2;
-  string command_line = 3;
-  string cwd = 4;
-  google.protobuf.Timestamp start_time = 5;
-  exa.codeium_common_pb.TerminalShellCommandSource source = 6;
-}
-
-message TerminalShellCommandData {  bytes raw_data = 1;
-}
-
-message TerminalShellCommandTrailer {  int32 exit_code = 1;
-  google.protobuf.Timestamp end_time = 2;
-}
-
-message TerminalShellCommandStreamChunk {  exa.codeium_common_pb.TerminalShellCommandHeader header = 1;
-  exa.codeium_common_pb.TerminalShellCommandData data = 2;
-  exa.codeium_common_pb.TerminalShellCommandTrailer trailer = 3;
-}
-
-message DocumentPosition {  uint64 row = 1;
-  uint64 col = 2;
-}
-
-message Range {  uint64 start_offset = 1;
-  uint64 end_offset = 2;
-  exa.codeium_common_pb.DocumentPosition start_position = 3;
-  exa.codeium_common_pb.DocumentPosition end_position = 4;
+message DiagnosticFix {  string id = 1;
+  string title = 2;
 }
 
 message CodeDiagnostic {  exa.codeium_common_pb.Range range = 1;
@@ -267,25 +593,31 @@ message CodeDiagnostic {  exa.codeium_common_pb.Range range = 1;
   string id = 6;
   exa.codeium_common_pb.Language language = 7;
   int64 score = 8;
+  repeated exa.codeium_common_pb.DiagnosticFix fixes = 9;
 }
 
-message LspReference {  string uri = 1;
-  exa.codeium_common_pb.Range range = 2;
-  string snippet = 3;
+message TerminalCommandData {  string terminal_id = 1;
+  string platform = 2;
+  string cwd = 3;
+  string shell_name = 4;
 }
 
-message GRPCStatus {  int32 code = 1;
-  string message = 2;
+message IntellisenseSuggestion {  exa.codeium_common_pb.Range range = 1;
+  string text = 2;
+  string label = 3;
+  string label_detail = 4;
+  string description = 5;
+  string detail = 6;
+  string documentation = 7;
+  string kind = 8;
+  bool selected = 9;
 }
 
-message ChatToolCall {  string id = 1;
-  string name = 2;
-  string arguments_json = 3;
-  string invalid_json_str = 4;
-  string invalid_json_err = 5;
+message SuperCompleteFilterReason {  string reason = 1;
 }
 
-message ModelUsageStats {  exa.codeium_common_pb.Model model = 1;
+message ModelUsageStats {  exa.codeium_common_pb.Model model_deprecated = 1;
+  string model_uid = 9;
   uint64 input_tokens = 2;
   uint64 output_tokens = 3;
   uint64 cache_write_tokens = 4;
@@ -295,10 +627,6 @@ message ModelUsageStats {  exa.codeium_common_pb.Model model = 1;
   map<string, string> response_header = 8;
 }
 
-message ModelOrAlias {  exa.codeium_common_pb.Model model = 1;
-  exa.codeium_common_pb.ModelAlias alias = 2;
-}
-
 message DeployTarget {  exa.codeium_common_pb.DeploymentProvider deployment_provider = 1;
   bool is_sandbox = 2;
   string provider_team_id = 3;
@@ -306,32 +634,13 @@ message DeployTarget {  exa.codeium_common_pb.DeploymentProvider deployment_prov
   string domain = 5;
 }
 
-message NotebookTrackedInfo {  string text = 1;
-  uint64 cursor_offset = 2;
+message ImageData {  string base64_data = 1;
+  string mime_type = 2;
+  string caption = 3;
 }
 
-message Document {  string absolute_path_migrate_me_to_uri = 1;
-  string absolute_uri = 12;
-  string relative_path_migrate_me_to_workspace_uri = 2;
-  string workspace_uri = 13;
-  string text = 3;
-  string editor_language = 4;
-  exa.codeium_common_pb.Language language = 5;
-  uint64 cursor_offset = 6;
-  exa.codeium_common_pb.DocumentPosition cursor_position = 8;
-  string line_ending = 7;
-  exa.codeium_common_pb.Range visible_range = 9;
-  bool is_cutoff_start = 10;
-  bool is_cutoff_end = 11;
-  int32 lines_cutoff_start = 14;
-  int32 lines_cutoff_end = 15;
-  google.protobuf.Timestamp timestamp = 16;
-  bool is_dirty = 17;
-  bool is_synthetic = 18;
-  bool is_notebook = 19;
-  exa.codeium_common_pb.NotebookTrackedInfo notebook_tracked_info = 20;
-  google.protobuf.Timestamp last_access_time = 21;
-  repeated exa.codeium_common_pb.Range selections = 22;
+message TextOrScopeItem {  string text = 1;
+  exa.codeium_common_pb.ContextScopeItem item = 2;
 }
 
 message DocumentQuery {  string text = 1;
@@ -448,21 +757,6 @@ message MQueryConfig {  bool should_batch_ccis = 1;
   uint32 top_cci_count = 10;
 }
 
-message PromptAnnotationRange {  exa.codeium_common_pb.PromptAnnotationKind kind = 1;
-  uint64 byte_offset_start = 2;
-  uint64 byte_offset_end = 3;
-  string suffix = 4;
-}
-
-message Repository {  string computed_name = 1;
-  string git_origin_url = 2;
-  string git_upstream_url = 3;
-  string reported_name = 4;
-  string model_name = 5;
-  string submodule_url = 6;
-  string submodule_path = 7;
-}
-
 message WindsurfDeployment {  string windsurf_deployment_id = 1;
   string auth_uid = 2;
   exa.codeium_common_pb.DeploymentProvider deployment_provider = 3;
@@ -492,6 +786,11 @@ message TextData {  string text = 1;
   string mime_type = 2;
 }
 
+message LspReference {  string uri = 1;
+  exa.codeium_common_pb.Range range = 2;
+  string snippet = 3;
+}
+
 message CodeAnnotation {  string id = 1;
   string uri = 2;
   uint32 line = 3;
@@ -499,202 +798,8 @@ message CodeAnnotation {  string id = 1;
   google.protobuf.Timestamp created_at = 5;
 }
 
-message EditorOptions {  uint64 tab_size = 1;
-  bool insert_spaces = 2;
-  bool disable_autocomplete_in_comments = 3;
-}
-
-message Completion {  string completion_id = 1;
-  string request_uid = 17;
-  string text = 2;
-  string stop = 4;
-  double score = 5;
-  repeated uint64 tokens = 6;
-  repeated string decoded_tokens = 7;
-  repeated double probabilities = 8;
-  repeated double adjusted_probabilities = 9;
-  repeated double logprobs = 16;
-  uint64 generated_length = 10;
-  exa.codeium_common_pb.StopReason stop_reason = 12;
-  repeated exa.codeium_common_pb.FilterReason filter_reasons = 13;
-  string original_text = 14;
-  repeated exa.codeium_common_pb.ChatToolCall tool_calls = 15;
-}
-
-message MockResponseData {  repeated exa.codeium_common_pb.Completion completions = 1;
-}
-
-message ExperimentWithVariant {  exa.codeium_common_pb.ExperimentKey key = 1;
-  string key_string = 5;
-  bool disabled = 6;
-  string string = 2;
-  string json = 3;
-  string csv = 4;
-  exa.codeium_common_pb.ExperimentSource source = 7;
-}
-
-message ExperimentConfig {  repeated exa.codeium_common_pb.ExperimentWithVariant experiments = 6;
-  repeated exa.codeium_common_pb.ExperimentKey force_enable_experiments = 1;
-  repeated exa.codeium_common_pb.ExperimentKey force_disable_experiments = 2;
-  repeated exa.codeium_common_pb.ExperimentWithVariant force_enable_experiments_with_variants = 3;
-  repeated string force_enable_experiment_strings = 4;
-  repeated string force_disable_experiment_strings = 5;
-  bool dev_mode = 7;
-}
-
-message CompletionConfiguration {  uint64 num_completions = 1;
-  uint64 max_tokens = 2;
-  uint64 max_newlines = 3;
-  double min_log_probability = 4;
-  double temperature = 5;
-  double first_temperature = 6;
-  uint64 top_k = 7;
-  double top_p = 8;
-  repeated string stop_patterns = 9;
-  uint64 seed = 10;
-  double fim_eot_prob_threshold = 11;
-  bool use_fim_eot_threshold = 12;
-  bool do_not_score_stop_tokens = 13;
-  bool sqrt_len_normalized_log_prob_score = 14;
-  bool last_message_is_partial = 15;
-  bool return_logprob = 16;
-}
-
-message PromptElementRange {  exa.codeium_common_pb.PromptElementKind kind = 1;
-  uint64 byte_offset_start = 2;
-  uint64 byte_offset_end = 3;
-  uint64 token_offset_start = 4;
-  uint64 token_offset_end = 5;
-}
-
-message PromptElementKindInfo {  exa.codeium_common_pb.PromptElementKind kind = 1;
-  exa.codeium_common_pb.ExperimentKey experiment_key = 2;
-  bool enabled = 3;
-  uint64 num_considered = 4;
-  uint64 num_included = 5;
-}
-
-message PromptStageLatency {  string name = 1;
-  uint64 latency_ms = 2;
-}
-
-message CompletionsRequest {  exa.codeium_common_pb.CompletionConfiguration configuration = 1;
-  string prompt = 2;
-  string context_prompt = 21;
-  string uid = 25;
-  repeated exa.codeium_common_pb.PromptElementRange prompt_element_ranges = 8;
-  repeated exa.codeium_common_pb.PromptElementKindInfo prompt_element_kind_infos = 9;
-  uint64 prompt_latency_ms = 11;
-  repeated exa.codeium_common_pb.PromptStageLatency prompt_stage_latencies = 12;
-  uint64 num_tokenized_bytes = 20;
-  string editor_language = 3;
-  exa.codeium_common_pb.Language language = 4;
-  string absolute_path_uri_for_telemetry = 5;
-  string relative_path_for_telemetry = 6;
-  string workspace_uri_for_telemetry = 13;
-  string experiment_features_json = 7;
-  string experiment_variant_json = 19;
-  exa.codeium_common_pb.Model model = 10;
-  bool has_line_suffix = 14;
-  bool should_inline_fim = 15;
-  exa.codeium_common_pb.Repository repository = 16;
-  string model_tag = 17;
-  repeated string experiment_tags = 18;
-  string eval_suffix = 22;
-  repeated exa.codeium_common_pb.PromptAnnotationRange prompt_annotation_ranges = 23;
-  bool supports_packed_streaming_completion_maps = 24;
-}
-
-message ErrorTrace {  string error_id = 1;
-  int64 timestamp_unix_ms = 2;
-  string stacktrace = 3;
-  bool recovered = 4;
-}
-
-message Status {  exa.codeium_common_pb.StatusLevel level = 1;
-  string message = 2;
-}
-
-message ClientModelConfig {  string label = 1;
-  exa.codeium_common_pb.ModelOrAlias model_or_alias = 2;
-  float credit_multiplier = 3;
-  exa.codeium_common_pb.ModelPricingType pricing_type = 13;
-  bool disabled = 4;
-  bool supports_images = 5;
-  bool supports_legacy = 6;
-  bool is_premium = 7;
-  string beta_warning_message = 8;
-  bool is_beta = 9;
-  exa.codeium_common_pb.ModelProvider provider = 10;
-  bool is_recommended = 11;
-  repeated exa.codeium_common_pb.TeamsTier allowed_tiers = 12;
-  exa.codeium_common_pb.APIProvider api_provider = 14;
-  bool is_new = 15;
-}
-
-message ClientModelGroup {  string group_name = 1;
-  repeated string model_labels = 2;
-}
-
-message ClientModelSort {  string name = 1;
-  repeated exa.codeium_common_pb.ClientModelGroup groups = 2;
-}
-
-message DefaultOverrideModelConfig {  exa.codeium_common_pb.ModelOrAlias model_or_alias = 1;
-  string version_id = 2;
-}
-
-message ExternalModel {  bool is_internal = 1;
-  exa.codeium_common_pb.Model model_id = 2;
-  string model_name = 3;
-  string base_url = 4;
-  string api_key = 5;
-  string access_key = 6;
-  string secret_access_key = 7;
-  string region = 8;
-  string project_id = 9;
-  uint32 id = 10;
-  int32 max_completion_tokens = 11;
-  int32 max_input_tokens = 12;
-}
-
-message Event {  exa.codeium_common_pb.EventType event_type = 1;
-  string event_json = 2;
-  int64 timestamp_unix_ms = 3;
-}
-
-message EmbeddingMetadata {  string node_name = 1;
-  uint32 start_line = 2;
-  uint32 end_line = 3;
-  exa.codeium_common_pb.EmbedType embed_type = 4;
-}
-
-message ContextScope {  repeated exa.codeium_common_pb.ContextScopeItem items = 1;
-}
-
-message ActionPointer {  string cortex_plan_id = 1;
-  string code_plan_id = 2;
-  int32 action_index = 3;
-}
-
-message TerminalCommandData {  string terminal_id = 1;
-  string platform = 2;
-  string cwd = 3;
-  string shell_name = 4;
-}
-
-message IntellisenseSuggestion {  exa.codeium_common_pb.Range range = 1;
-  string text = 2;
-  string label = 3;
-  string label_detail = 4;
-  string description = 5;
-  string detail = 6;
-  string documentation = 7;
-  string kind = 8;
-  bool selected = 9;
-}
-
-message SuperCompleteFilterReason {  string reason = 1;
+message FileRangeContent {  string content = 1;
+  exa.codeium_common_pb.FileLineRange source = 2;
 }
 
 message WorkspaceStats {  string workspace = 3;
@@ -706,28 +811,6 @@ message WorkspaceStats {  string workspace = 3;
 message PartialIndexMetadata {  uint32 num_total_files = 1;
   uint32 num_indexed_files = 2;
   google.protobuf.Timestamp cutoff_timestamp = 3;
-}
-
-message McpCommandTemplate {  string command = 1;
-  repeated string args = 2;
-  map<string, string> env = 3;
-}
-
-message McpCommandVariable {  string name = 1;
-  string title = 2;
-  string description = 3;
-  string link = 4;
-}
-
-message McpServerCommand {  exa.codeium_common_pb.McpCommandTemplate template = 1;
-  repeated exa.codeium_common_pb.McpCommandVariable variables = 2;
-}
-
-message McpServerTemplate {  string title = 1;
-  string id = 2;
-  string link = 3;
-  string description = 4;
-  map<string, exa.codeium_common_pb.McpServerCommand> commands = 5;
 }
 
 message FunctionInfo {  string raw_source = 1;
@@ -815,6 +898,16 @@ message TeamConfig {  string team_id = 1;
   bool allow_vibe_and_replace = 27;
   bool disable_deepwiki = 28;
   exa.codeium_common_pb.CustomProviderSettings custom_provider_settings = 29;
+  int32 user_add_on_credit_cap = 30;
+  bool disable_codemaps = 31;
+  string allow_codemap_sharing = 32;
+  bool disable_fast_context = 33;
+  bool disable_lifeguard = 34;
+  repeated string allowed_ip_ranges = 35;
+  exa.codeium_common_pb.CascadeCommandsAutoExecution max_cascade_auto_execution_level = 37;
+  bool cascade_web_search_enabled = 38;
+  repeated string terminal_allow_list = 39;
+  repeated string terminal_deny_list = 40;
 }
 
 message TeamsFeaturesMetadata {  bool is_active = 1;
@@ -841,6 +934,7 @@ message PlanInfo {  exa.codeium_common_pb.TeamsTier teams_tier = 1;
   int32 monthly_flex_credit_purchase_amount = 14;
   bool is_teams = 17;
   bool is_enterprise = 16;
+  bool has_paid_features = 32;
   bool can_buy_more_credits = 18;
   bool cascade_web_search_enabled = 19;
   bool can_customize_app_icon = 20;
@@ -879,14 +973,17 @@ message UserSettings {  bool open_most_recent_chat_conversation = 1;
   string last_selected_model_name = 8;
   repeated exa.codeium_common_pb.CascadeNUXState cascade_nux_states = 11;
   map<uint32, bool> seen_nux_uids = 60;
-  exa.codeium_common_pb.Model last_selected_cascade_model = 9;
-  exa.codeium_common_pb.ModelOrAlias last_selected_cascade_model_or_alias = 30;
+  exa.codeium_common_pb.Model last_selected_cascade_model_deprecated = 9;
+  exa.codeium_common_pb.ModelOrAlias last_selected_cascade_model_or_alias_deprecated = 30;
+  string last_selected_cascade_model_uid = 91;
   exa.codeium_common_pb.ConversationalPlannerMode cascade_planner_mode = 13;
-  exa.codeium_common_pb.ClaudeCodeMode claude_code_mode = 73;
   exa.codeium_common_pb.Model last_model_override = 46;
   string last_model_default_override_version_id = 58;
-  repeated string cascade_allowed_commands = 14;
-  repeated string cascade_denied_commands = 15;
+  bool cascade_model_explicitly_set = 87;
+  repeated string cascade_allowed_commands_prefix = 14;
+  repeated string cascade_denied_commands_prefix = 15;
+  repeated string cascade_allowed_commands = 85;
+  repeated string cascade_denied_commands = 86;
   repeated exa.codeium_common_pb.UserNUXState user_nux_states = 17;
   bool cascade_web_search_disabled = 18;
   bool disable_autocomplete = 19;
@@ -924,8 +1021,6 @@ message UserSettings {  bool open_most_recent_chat_conversation = 1;
   exa.codeium_common_pb.PlanMode global_plan_mode_preference = 54;
   repeated exa.codeium_common_pb.ClientModelConfig cached_cascade_model_configs = 52;
   repeated exa.codeium_common_pb.ClientModelSort cached_cascade_model_sorts = 53;
-  exa.codeium_common_pb.CascadeRunExtensionCode cascade_run_extension_code = 56;
-  exa.codeium_common_pb.CascadeRunExtensionCodeAutoRun cascade_run_extension_code_auto_run = 57;
   exa.codeium_common_pb.AutoContinueOnMaxGeneratorInvocations auto_continue_on_max_generator_invocations = 59;
   repeated string recently_used_cascade_models = 61;
   repeated string cascade_dismissed_suggestion_workspaces = 62;
@@ -933,54 +1028,21 @@ message UserSettings {  bool open_most_recent_chat_conversation = 1;
   bool enable_automatic_screenshot = 64;
   exa.codeium_common_pb.BrowserExperimentalFeaturesConfig browser_experimental_features_config = 66;
   exa.codeium_common_pb.CommandPopupAutocomplete command_popup_autocomplete = 67;
-  string claude_code_cli_path = 68;
-  string claude_code_system_prompt = 70;
-  uint32 claude_code_max_turns = 71;
-  string claude_code_mcp_config = 72;
-  repeated string claude_code_directories = 74;
-  string claude_code_system_prompt_append = 75;
-  string claude_code_model = 76;
+  bool enable_instant_context_agent = 77;
+  bool disable_instant_context_agent = 78;
+  exa.codeium_common_pb.Model last_selected_smart_friend_model_deprecated = 79;
+  string last_selected_smart_friend_model_uid = 92;
+  bool enable_cascade_completion_notifications = 81;
+  bool enable_cascade_always_notify_on_finish = 82;
+  exa.codeium_common_pb.CompletionMode completion_mode = 83;
+  bool enable_inlay_hint_shortcuts = 84;
+  repeated string cascade_user_allowed_web_origins = 88;
+  repeated string cascade_removed_default_web_origins = 89;
+  exa.codeium_common_pb.CascadeWebRequestsAutoExecution cascade_web_requests_auto_execution_policy = 90;
+  repeated string last_specific_arena_model_uids = 93;
 }
 
 message LanguageServerDiagnostics {  repeated string logs = 1;
-}
-
-message CompletionStatistics {  uint32 num_acceptances = 1;
-  uint32 num_rejections = 2;
-  uint32 num_lines_accepted = 3;
-  uint32 num_bytes_accepted = 4;
-  uint32 num_users = 5;
-  uint32 active_developer_days = 6;
-  uint32 active_developer_hours = 7;
-}
-
-message CompletionByDateEntry {  google.protobuf.Timestamp timestamp = 1;
-  exa.codeium_common_pb.CompletionStatistics completion_statistics = 2;
-}
-
-message CompletionByLanguageEntry {  exa.codeium_common_pb.Language language = 1;
-  exa.codeium_common_pb.CompletionStatistics completion_statistics = 2;
-}
-
-message ChatStats {  uint64 chats_sent = 1;
-  uint64 chats_received = 2;
-  uint64 chats_accepted = 3;
-  uint64 chats_inserted_at_cursor = 4;
-  uint64 chats_applied = 5;
-  uint64 chat_loc_used = 6;
-  uint64 chat_code_blocks_used = 7;
-  uint64 function_explain_count = 8;
-  uint64 function_docstring_count = 9;
-  uint64 function_refactor_count = 10;
-  uint64 code_block_explain_count = 11;
-  uint64 code_block_refactor_count = 12;
-  uint64 problem_explain_count = 13;
-  uint64 function_unit_tests_count = 14;
-  uint32 active_developer_days = 15;
-}
-
-message ChatStatsByModelEntry {  exa.codeium_common_pb.Model model_id = 1;
-  exa.codeium_common_pb.ChatStats chat_stats = 2;
 }
 
 message TopUpStatus {  exa.codeium_common_pb.TransactionStatus top_up_transaction_status = 1;
@@ -1001,6 +1063,7 @@ message PlanStatus {  exa.codeium_common_pb.PlanInfo plan_info = 1;
   int32 used_flow_credits = 5;
   int32 used_prompt_credits = 6;
   exa.codeium_common_pb.TopUpStatus top_up_status = 10;
+  bool was_reduced_by_orphaned_usage = 11;
 }
 
 message CascadeModelConfigData {  repeated exa.codeium_common_pb.ClientModelConfig client_model_configs = 1;
@@ -1017,8 +1080,8 @@ message UserStatus {  bool pro = 1;
   string email = 7;
   repeated exa.codeium_common_pb.UserFeatures user_features = 9;
   repeated exa.codeium_common_pb.TeamsFeatures teams_features = 8;
+  exa.codeium_common_pb.TeamsTier teams_tier = 10;
   repeated exa.codeium_common_pb.Permission permissions = 11;
-  exa.codeium_common_pb.PlanInfo plan_info = 12;
   exa.codeium_common_pb.PlanStatus plan_status = 13;
   bool has_used_windsurf = 31;
   int64 user_used_prompt_credits = 28;
@@ -1026,6 +1089,8 @@ message UserStatus {  bool pro = 1;
   bool has_fingerprint_set = 30;
   exa.codeium_common_pb.TeamConfig team_config = 32;
   exa.codeium_common_pb.CascadeModelConfigData cascade_model_config_data = 33;
+  google.protobuf.Timestamp windsurf_pro_trial_end_time = 34;
+  int64 max_num_premium_chat_messages = 35;
 }
 
 message CaptureFileRequestData {  exa.codeium_common_pb.Metadata metadata = 1;
@@ -1037,6 +1102,28 @@ message CaptureFileRequestData {  exa.codeium_common_pb.Metadata metadata = 1;
   uint64 end_offset = 7;
   uint64 cursor_line = 8;
   uint64 cursor_column = 9;
+}
+
+message TerminalShellCommandHeader {  exa.codeium_common_pb.Metadata metadata = 7;
+  string terminal_id = 1;
+  string command_line = 3;
+  string cwd = 4;
+  google.protobuf.Timestamp start_time = 5;
+  exa.codeium_common_pb.TerminalShellCommandSource source = 6;
+}
+
+message TerminalShellCommandData {  bytes raw_data = 1;
+}
+
+message TerminalShellCommandTrailer {  int32 exit_code = 1;
+  google.protobuf.Timestamp end_time = 2;
+  string full_output = 3;
+  string ansi_output = 4;
+}
+
+message TerminalShellCommandStreamChunk {  exa.codeium_common_pb.TerminalShellCommandHeader header = 1;
+  exa.codeium_common_pb.TerminalShellCommandData data = 2;
+  exa.codeium_common_pb.TerminalShellCommandTrailer trailer = 3;
 }
 
 message WebDocsOption {  string label = 1;
@@ -1052,6 +1139,7 @@ message UnleashContext {  string user_id = 1;
 }
 
 message ModelStatusInfo {  exa.codeium_common_pb.Model model = 1;
+  string model_uid = 4;
   string message = 2;
   exa.codeium_common_pb.ModelStatus status = 3;
 }
@@ -1062,64 +1150,67 @@ message TeamOrganizationalControls {  string team_id = 1;
   google.protobuf.Timestamp created_at = 4;
   google.protobuf.Timestamp updated_at = 5;
   repeated string extension_model_labels = 6;
+  repeated exa.codeium_common_pb.APIProvider allowed_api_providers = 8;
+  repeated string cli_model_labels = 9;
 }
 
-message CascadeNUXConfig {  uint32 uid = 1;
-  exa.codeium_common_pb.CascadeNUXLocation location = 2;
-  exa.codeium_common_pb.CascadeNUXTrigger trigger = 3;
-  string analytics_event_name = 4;
-  string main_text = 5;
-  string on_hover_explanation = 6;
-  string learn_more_url = 7;
-  int32 priority = 8;
-  exa.codeium_common_pb.CascadeNUXEvent old_nux_event = 9;
-  exa.codeium_common_pb.CascadeNUXIcon icon = 10;
-  bool requires_idle_cascade = 11;
+message GRPCStatus {  int32 code = 1;
+  string message = 2;
 }
 
+message LifeguardModeConfig {  bool enabled = 1;
+  exa.codeium_common_pb.Model model = 2;
+  string model_display_name = 3;
+  string agent_version = 4;
+}
+
+message LifeguardConfig {  map<string, exa.codeium_common_pb.LifeguardModeConfig> modes = 1;
+}
+
+enum AuthSource {  AUTH_SOURCE_CODEIUM = 0;  AUTH_SOURCE_DEEPNOTE = 1;  AUTH_SOURCE_CODESANDBOX = 2;  AUTH_SOURCE_STACKBLITZ = 3;  AUTH_SOURCE_VALTOWN = 4;  AUTH_SOURCE_HEX = 5;  AUTH_SOURCE_ZAPIER = 6;  AUTH_SOURCE_SUPERBLOCKS = 7;  AUTH_SOURCE_EMBARCADERO = 8;}
+enum Language {  LANGUAGE_UNSPECIFIED = 0;  LANGUAGE_C = 1;  LANGUAGE_CLOJURE = 2;  LANGUAGE_COFFEESCRIPT = 3;  LANGUAGE_CPP = 4;  LANGUAGE_CSHARP = 5;  LANGUAGE_CSS = 6;  LANGUAGE_CUDACPP = 7;  LANGUAGE_DOCKERFILE = 8;  LANGUAGE_GO = 9;  LANGUAGE_GROOVY = 10;  LANGUAGE_HANDLEBARS = 11;  LANGUAGE_HASKELL = 12;  LANGUAGE_HCL = 13;  LANGUAGE_HTML = 14;  LANGUAGE_INI = 15;  LANGUAGE_JAVA = 16;  LANGUAGE_JAVASCRIPT = 17;  LANGUAGE_JSON = 18;  LANGUAGE_JULIA = 19;  LANGUAGE_KOTLIN = 20;  LANGUAGE_LATEX = 21;  LANGUAGE_LESS = 22;  LANGUAGE_LUA = 23;  LANGUAGE_MAKEFILE = 24;  LANGUAGE_MARKDOWN = 25;  LANGUAGE_OBJECTIVEC = 26;  LANGUAGE_OBJECTIVECPP = 27;  LANGUAGE_PERL = 28;  LANGUAGE_PHP = 29;  LANGUAGE_PLAINTEXT = 30;  LANGUAGE_PROTOBUF = 31;  LANGUAGE_PBTXT = 32;  LANGUAGE_PYTHON = 33;  LANGUAGE_R = 34;  LANGUAGE_RUBY = 35;  LANGUAGE_RUST = 36;  LANGUAGE_SASS = 37;  LANGUAGE_SCALA = 38;  LANGUAGE_SCSS = 39;  LANGUAGE_SHELL = 40;  LANGUAGE_SQL = 41;  LANGUAGE_STARLARK = 42;  LANGUAGE_SWIFT = 43;  LANGUAGE_TSX = 44;  LANGUAGE_TYPESCRIPT = 45;  LANGUAGE_VISUALBASIC = 46;  LANGUAGE_VUE = 47;  LANGUAGE_XML = 48;  LANGUAGE_XSL = 49;  LANGUAGE_YAML = 50;  LANGUAGE_SVELTE = 51;  LANGUAGE_TOML = 52;  LANGUAGE_DART = 53;  LANGUAGE_RST = 54;  LANGUAGE_OCAML = 55;  LANGUAGE_CMAKE = 56;  LANGUAGE_PASCAL = 57;  LANGUAGE_ELIXIR = 58;  LANGUAGE_FSHARP = 59;  LANGUAGE_LISP = 60;  LANGUAGE_MATLAB = 61;  LANGUAGE_POWERSHELL = 62;  LANGUAGE_SOLIDITY = 63;  LANGUAGE_ADA = 64;  LANGUAGE_OCAML_INTERFACE = 65;  LANGUAGE_TREE_SITTER_QUERY = 66;  LANGUAGE_APL = 67;  LANGUAGE_ASSEMBLY = 68;  LANGUAGE_COBOL = 69;  LANGUAGE_CRYSTAL = 70;  LANGUAGE_EMACS_LISP = 71;  LANGUAGE_ERLANG = 72;  LANGUAGE_FORTRAN = 73;  LANGUAGE_FREEFORM = 74;  LANGUAGE_GRADLE = 75;  LANGUAGE_HACK = 76;  LANGUAGE_MAVEN = 77;  LANGUAGE_M68KASSEMBLY = 78;  LANGUAGE_SAS = 79;  LANGUAGE_UNIXASSEMBLY = 80;  LANGUAGE_VBA = 81;  LANGUAGE_VIMSCRIPT = 82;  LANGUAGE_WEBASSEMBLY = 83;  LANGUAGE_BLADE = 84;  LANGUAGE_ASTRO = 85;  LANGUAGE_MUMPS = 86;  LANGUAGE_GDSCRIPT = 87;  LANGUAGE_NIM = 88;  LANGUAGE_PROLOG = 89;  LANGUAGE_MARKDOWN_INLINE = 90;  LANGUAGE_APEX = 91;  LANGUAGE_JUPYTER_NOTEBOOK = 92;}
+enum StopReason {  STOP_REASON_UNSPECIFIED = 0;  STOP_REASON_INCOMPLETE = 1;  STOP_REASON_STOP_PATTERN = 2;  STOP_REASON_MAX_TOKENS = 3;  STOP_REASON_MIN_LOG_PROB = 4;  STOP_REASON_MAX_NEWLINES = 5;  STOP_REASON_EXIT_SCOPE = 6;  STOP_REASON_NONFINITE_LOGIT_OR_PROB = 7;  STOP_REASON_FIRST_NON_WHITESPACE_LINE = 8;  STOP_REASON_PARTIAL = 9;  STOP_REASON_FUNCTION_CALL = 10;  STOP_REASON_CONTENT_FILTER = 11;  STOP_REASON_NON_INSERTION = 12;  STOP_REASON_ERROR = 13;}
+enum FilterReason {  FILTER_REASON_NONE = 0;  FILTER_REASON_INCOMPLETE = 1;  FILTER_REASON_EMPTY = 2;  FILTER_REASON_REPETITIVE = 3;  FILTER_REASON_DUPLICATE = 4;  FILTER_REASON_LONG_LINE = 5;  FILTER_REASON_COMPLETIONS_CUTOFF = 6;  FILTER_REASON_ATTRIBUTION = 7;  FILTER_REASON_NON_MATCHING = 8;  FILTER_REASON_NON_INSERTION = 9;}
+enum CodeContextType {  CODE_CONTEXT_TYPE_UNSPECIFIED = 0;  CODE_CONTEXT_TYPE_FUNCTION = 1;  CODE_CONTEXT_TYPE_CLASS = 2;  CODE_CONTEXT_TYPE_IMPORT = 3;  CODE_CONTEXT_TYPE_NAIVE_LINECHUNK = 4;  CODE_CONTEXT_TYPE_REFERENCE_FUNCTION = 5;  CODE_CONTEXT_TYPE_REFERENCE_CLASS = 6;  CODE_CONTEXT_TYPE_FILE = 7;  CODE_CONTEXT_TYPE_TERMINAL = 8;  CODE_CONTEXT_TYPE_DIRECTORY = 9;}
 enum ScmProvider {  SCM_PROVIDER_UNSPECIFIED = 0;  SCM_PROVIDER_GITHUB = 1;  SCM_PROVIDER_GITLAB = 2;  SCM_PROVIDER_BITBUCKET = 3;  SCM_PROVIDER_AZURE_DEVOPS = 4;}
-enum CodeContextType {  CODE_CONTEXT_TYPE_UNSPECIFIED = 0;  CODE_CONTEXT_TYPE_FUNCTION = 1;  CODE_CONTEXT_TYPE_CLASS = 2;  CODE_CONTEXT_TYPE_IMPORT = 3;  CODE_CONTEXT_TYPE_NAIVE_LINECHUNK = 4;  CODE_CONTEXT_TYPE_REFERENCE_FUNCTION = 5;  CODE_CONTEXT_TYPE_REFERENCE_CLASS = 6;  CODE_CONTEXT_TYPE_FILE = 7;  CODE_CONTEXT_TYPE_TERMINAL = 8;}
-enum Language {  LANGUAGE_UNSPECIFIED = 0;  LANGUAGE_C = 1;  LANGUAGE_CLOJURE = 2;  LANGUAGE_COFFEESCRIPT = 3;  LANGUAGE_CPP = 4;  LANGUAGE_CSHARP = 5;  LANGUAGE_CSS = 6;  LANGUAGE_CUDACPP = 7;  LANGUAGE_DOCKERFILE = 8;  LANGUAGE_GO = 9;  LANGUAGE_GROOVY = 10;  LANGUAGE_HANDLEBARS = 11;  LANGUAGE_HASKELL = 12;  LANGUAGE_HCL = 13;  LANGUAGE_HTML = 14;  LANGUAGE_INI = 15;  LANGUAGE_JAVA = 16;  LANGUAGE_JAVASCRIPT = 17;  LANGUAGE_JSON = 18;  LANGUAGE_JULIA = 19;  LANGUAGE_KOTLIN = 20;  LANGUAGE_LATEX = 21;  LANGUAGE_LESS = 22;  LANGUAGE_LUA = 23;  LANGUAGE_MAKEFILE = 24;  LANGUAGE_MARKDOWN = 25;  LANGUAGE_OBJECTIVEC = 26;  LANGUAGE_OBJECTIVECPP = 27;  LANGUAGE_PERL = 28;  LANGUAGE_PHP = 29;  LANGUAGE_PLAINTEXT = 30;  LANGUAGE_PROTOBUF = 31;  LANGUAGE_PBTXT = 32;  LANGUAGE_PYTHON = 33;  LANGUAGE_R = 34;  LANGUAGE_RUBY = 35;  LANGUAGE_RUST = 36;  LANGUAGE_SASS = 37;  LANGUAGE_SCALA = 38;  LANGUAGE_SCSS = 39;  LANGUAGE_SHELL = 40;  LANGUAGE_SQL = 41;  LANGUAGE_STARLARK = 42;  LANGUAGE_SWIFT = 43;  LANGUAGE_TSX = 44;  LANGUAGE_TYPESCRIPT = 45;  LANGUAGE_VISUALBASIC = 46;  LANGUAGE_VUE = 47;  LANGUAGE_XML = 48;  LANGUAGE_XSL = 49;  LANGUAGE_YAML = 50;  LANGUAGE_SVELTE = 51;  LANGUAGE_TOML = 52;  LANGUAGE_DART = 53;  LANGUAGE_RST = 54;  LANGUAGE_OCAML = 55;  LANGUAGE_CMAKE = 56;  LANGUAGE_PASCAL = 57;  LANGUAGE_ELIXIR = 58;  LANGUAGE_FSHARP = 59;  LANGUAGE_LISP = 60;  LANGUAGE_MATLAB = 61;  LANGUAGE_POWERSHELL = 62;  LANGUAGE_SOLIDITY = 63;  LANGUAGE_ADA = 64;  LANGUAGE_OCAML_INTERFACE = 65;  LANGUAGE_TREE_SITTER_QUERY = 66;  LANGUAGE_APL = 67;  LANGUAGE_ASSEMBLY = 68;  LANGUAGE_COBOL = 69;  LANGUAGE_CRYSTAL = 70;  LANGUAGE_EMACS_LISP = 71;  LANGUAGE_ERLANG = 72;  LANGUAGE_FORTRAN = 73;  LANGUAGE_FREEFORM = 74;  LANGUAGE_GRADLE = 75;  LANGUAGE_HACK = 76;  LANGUAGE_MAVEN = 77;  LANGUAGE_M68KASSEMBLY = 78;  LANGUAGE_SAS = 79;  LANGUAGE_UNIXASSEMBLY = 80;  LANGUAGE_VBA = 81;  LANGUAGE_VIMSCRIPT = 82;  LANGUAGE_WEBASSEMBLY = 83;  LANGUAGE_BLADE = 84;  LANGUAGE_ASTRO = 85;  LANGUAGE_MUMPS = 86;  LANGUAGE_GDSCRIPT = 87;  LANGUAGE_NIM = 88;  LANGUAGE_PROLOG = 89;  LANGUAGE_MARKDOWN_INLINE = 90;  LANGUAGE_APEX = 91;}
+enum Model {  MODEL_UNSPECIFIED = 0;  MODEL_EMBED_6591 = 20;  MODEL_8341 = 33;  MODEL_8528 = 42;  MODEL_9024 = 41;  MODEL_14602 = 112;  MODEL_15133 = 115;  MODEL_15302 = 119;  MODEL_15335 = 121;  MODEL_15336 = 122;  MODEL_15931 = 167;  MODEL_QUERY_9905 = 48;  MODEL_QUERY_11791 = 66;  MODEL_CHAT_11120 = 57;  MODEL_CHAT_11121 = 58;  MODEL_CHAT_12119 = 70;  MODEL_CHAT_12121 = 69;  MODEL_CHAT_12437 = 74;  MODEL_CHAT_12491 = 76;  MODEL_CHAT_12623 = 78;  MODEL_CHAT_12950 = 79;  MODEL_CHAT_12968 = 101;  MODEL_CHAT_13404 = 102;  MODEL_CHAT_13566 = 103;  MODEL_CHAT_13930 = 108;  MODEL_CHAT_14255 = 110;  MODEL_CHAT_14256 = 111;  MODEL_CHAT_14942 = 114;  MODEL_CHAT_15305 = 120;  MODEL_CHAT_15600 = 123;  MODEL_CHAT_16801 = 124;  MODEL_CHAT_16718 = 175;  MODEL_CHAT_15729 = 168;  MODEL_CHAT_16579 = 173;  MODEL_CHAT_16579_CRUSOE = 174;  MODEL_CHAT_18805 = 181;  MODEL_CHAT_18468 = 210;  MODEL_CHAT_19484 = 233;  MODEL_CHAT_20706 = 235;  MODEL_CHAT_21779 = 245;  MODEL_CHAT_19040 = 211;  MODEL_CHAT_19820 = 229;  MODEL_CHAT_19821 = 230;  MODEL_CHAT_19821_CRUSOE = 244;  MODEL_CHAT_23310 = 269;  MODEL_CHAT_28580 = 330;  MODEL_CHAT_28581 = 331;  MODEL_CHAT_28582 = 332;  MODEL_CHAT_28583 = 333;  MODEL_CHAT_28584 = 334;  MODEL_CHAT_19822 = 231;  MODEL_CHAT_22798 = 255;  MODEL_CHAT_22799 = 256;  MODEL_CHAT_22800 = 257;  MODEL_CHAT_23151 = 267;  MODEL_CHAT_23152 = 268;  MODEL_TAB_ARMADILLO = 500;  MODEL_TAB_BASE_1 = 501;  MODEL_TAB_EXPERIMENTAL_1 = 502;  MODEL_TAB_EXPERIMENTAL_2 = 503;  MODEL_TAB_EXPERIMENTAL_3 = 504;  MODEL_TAB_EXPERIMENTAL_4 = 505;  MODEL_TAB_EXPERIMENTAL_5 = 506;  MODEL_TAB_EXPERIMENTAL_6 = 507;  MODEL_TAB_EXPERIMENTAL_7 = 508;  MODEL_TAB_EXPERIMENTAL_8 = 509;  MODEL_TAB_EXPERIMENTAL_9 = 510;  MODEL_TAB_EXPERIMENTAL_10 = 511;  MODEL_CASCADE_22893 = 270;  MODEL_CASCADE_20064 = 225;  MODEL_CASCADE_20065 = 236;  MODEL_CASCADE_20066 = 237;  MODEL_CASCADE_20067 = 238;  MODEL_CASCADE_20068 = 239;  MODEL_CASCADE_20069 = 240;  MODEL_CASCADE_20070 = 250;  MODEL_CASCADE_20071 = 251;  MODEL_CASCADE_20072 = 252;  MODEL_CASCADE_20073 = 253;  MODEL_CASCADE_20074 = 254;  MODEL_CASCADE_20075 = 307;  MODEL_CASCADE_20076 = 308;  MODEL_CASCADE_20077 = 309;  MODEL_CASCADE_20078 = 310;  MODEL_CASCADE_20079 = 311;  MODEL_CASCADE_20080 = 297;  MODEL_CASCADE_20081 = 298;  MODEL_CASCADE_20082 = 299;  MODEL_CASCADE_20083 = 300;  MODEL_CASCADE_20084 = 301;  MODEL_CASCADE_20085 = 302;  MODEL_CASCADE_20086 = 303;  MODEL_CASCADE_20087 = 304;  MODEL_CASCADE_20088 = 305;  MODEL_CASCADE_20089 = 306;  MODEL_DEEPSEEK_V3_INTERNAL = 247;  MODEL_DEEPSEEK_V3_0324_INTERNAL = 248;  MODEL_DEEPSEEK_R1_INTERNAL = 249;  MODEL_ANTHROPIC_WINDSURF_RESEARCH = 241;  MODEL_ANTHROPIC_WINDSURF_RESEARCH_THINKING = 242;  MODEL_DRAFT_11408 = 65;  MODEL_DRAFT_CHAT_11883 = 67;  MODEL_DRAFT_CHAT_12196 = 72;  MODEL_DRAFT_CHAT_12413 = 73;  MODEL_DRAFT_CHAT_13175 = 104;  MODEL_DRAFT_CHAT_19823 = 232;  MODEL_DRAFT_CHAT_20707 = 243;  MODEL_DRAFT_CHAT_22801 = 258;  MODEL_DRAFT_CHAT_23508 = 273;  MODEL_DRAFT_CASCADE_23672 = 274;  MODEL_CHAT_3_5_TURBO = 28;  MODEL_CHAT_GPT_4 = 30;  MODEL_CHAT_GPT_4_1106_PREVIEW = 37;  MODEL_TEXT_EMBEDDING_OPENAI_ADA = 91;  MODEL_TEXT_EMBEDDING_OPENAI_3_SMALL = 163;  MODEL_TEXT_EMBEDDING_OPENAI_3_LARGE = 164;  MODEL_CHAT_GPT_4O_2024_05_13 = 71;  MODEL_CHAT_GPT_4O_2024_08_06 = 109;  MODEL_CHAT_GPT_4O_MINI_2024_07_18 = 113;  MODEL_CHAT_GPT_4_1_2025_04_14 = 259;  MODEL_CHAT_GPT_4_1_MINI_2025_04_14 = 260;  MODEL_CHAT_GPT_4_1_NANO_2025_04_14 = 261;  MODEL_CHAT_O1_PREVIEW = 117;  MODEL_CHAT_O1_MINI = 118;  MODEL_CHAT_O1 = 170;  MODEL_CHAT_O3_MINI = 207;  MODEL_CHAT_O3_MINI_LOW = 213;  MODEL_CHAT_O3_MINI_HIGH = 214;  MODEL_CHAT_O3 = 218;  MODEL_CHAT_O3_LOW = 262;  MODEL_CHAT_O3_HIGH = 263;  MODEL_CHAT_O4_MINI = 264;  MODEL_CHAT_O4_MINI_LOW = 265;  MODEL_CHAT_O4_MINI_HIGH = 266;  MODEL_CHAT_GPT_4_5 = 228;  MODEL_CODEX_MINI_LATEST = 287;  MODEL_CODEX_MINI_LATEST_LOW = 288;  MODEL_CODEX_MINI_LATEST_HIGH = 289;  MODEL_O3_PRO_2025_06_10 = 294;  MODEL_O3_PRO_2025_06_10_LOW = 295;  MODEL_O3_PRO_2025_06_10_HIGH = 296;  MODEL_GPT_OSS_120B = 326;  MODEL_GPT_5_NANO = 337;  MODEL_CHAT_GPT_5_MINIMAL = 338;  MODEL_CHAT_GPT_5_LOW = 339;  MODEL_CHAT_GPT_5 = 340;  MODEL_CHAT_GPT_5_HIGH = 341;  MODEL_CHAT_GPT_5_CODEX = 346;  MODEL_GPT_5_1_CODEX_MINI_LOW = 385;  MODEL_GPT_5_1_CODEX_MINI_MEDIUM = 386;  MODEL_GPT_5_1_CODEX_MINI_HIGH = 387;  MODEL_GPT_5_1_CODEX_LOW = 388;  MODEL_GPT_5_1_CODEX_MEDIUM = 389;  MODEL_GPT_5_1_CODEX_HIGH = 390;  MODEL_GPT_5_1_CODEX_MAX_LOW = 395;  MODEL_GPT_5_1_CODEX_MAX_MEDIUM = 396;  MODEL_GPT_5_1_CODEX_MAX_HIGH = 397;  MODEL_GOOGLE_GEMINI_1_0_PRO = 61;  MODEL_GOOGLE_GEMINI_1_5_PRO = 62;  MODEL_GOOGLE_GEMINI_EXP_1206 = 183;  MODEL_GOOGLE_GEMINI_2_0_FLASH = 184;  MODEL_GOOGLE_GEMINI_2_5_PRO = 246;  MODEL_GOOGLE_GEMINI_2_5_FLASH_PREVIEW_04_17 = 272;  MODEL_GOOGLE_GEMINI_2_5_FLASH_PREVIEW_05_20 = 275;  MODEL_GOOGLE_GEMINI_2_5_FLASH_PREVIEW_05_20_THINKING = 276;  MODEL_GOOGLE_GEMINI_2_5_FLASH = 312;  MODEL_GOOGLE_GEMINI_2_5_FLASH_THINKING = 313;  MODEL_GOOGLE_GEMINI_2_5_FLASH_LITE = 343;  MODEL_GOOGLE_GEMINI_3_0_PRO_LOW = 378;  MODEL_GOOGLE_GEMINI_3_0_PRO_HIGH = 379;  MODEL_GOOGLE_GEMINI_3_0_PRO_MINIMAL = 411;  MODEL_GOOGLE_GEMINI_3_0_PRO_MEDIUM = 412;  MODEL_GOOGLE_GEMINI_3_0_FLASH_MINIMAL = 413;  MODEL_GOOGLE_GEMINI_3_0_FLASH_LOW = 414;  MODEL_GOOGLE_GEMINI_3_0_FLASH_MEDIUM = 415;  MODEL_GOOGLE_GEMINI_3_0_FLASH_HIGH = 416;  MODEL_CLAUDE_3_OPUS_20240229 = 63;  MODEL_CLAUDE_3_SONNET_20240229 = 64;  MODEL_CLAUDE_3_HAIKU_20240307 = 172;  MODEL_CLAUDE_3_5_HAIKU_20241022 = 171;  MODEL_CLAUDE_3_5_SONNET_20240620 = 80;  MODEL_CLAUDE_3_5_SONNET_20241022 = 166;  MODEL_CLAUDE_3_7_SONNET_20250219 = 226;  MODEL_CLAUDE_3_7_SONNET_20250219_THINKING = 227;  MODEL_CLAUDE_3_5_SONNET_BYOK = 284;  MODEL_CLAUDE_3_7_SONNET_BYOK = 285;  MODEL_CLAUDE_3_7_SONNET_OPEN_ROUTER_BYOK = 319;  MODEL_CLAUDE_3_7_SONNET_THINKING_BYOK = 286;  MODEL_CLAUDE_3_7_SONNET_THINKING_OPEN_ROUTER_BYOK = 320;  MODEL_CLAUDE_4_OPUS_BYOK = 277;  MODEL_CLAUDE_4_OPUS_THINKING_BYOK = 278;  MODEL_CLAUDE_4_OPUS = 290;  MODEL_CLAUDE_4_OPUS_THINKING = 291;  MODEL_CLAUDE_4_SONNET_BYOK = 279;  MODEL_CLAUDE_4_SONNET_OPEN_ROUTER_BYOK = 321;  MODEL_CLAUDE_4_SONNET_THINKING_BYOK = 280;  MODEL_CLAUDE_4_SONNET_THINKING_OPEN_ROUTER_BYOK = 322;  MODEL_CLAUDE_4_SONNET = 281;  MODEL_CLAUDE_4_SONNET_THINKING = 282;  MODEL_CLAUDE_4_1_OPUS = 328;  MODEL_CLAUDE_4_1_OPUS_THINKING = 329;  MODEL_CLAUDE_4_5_SONNET = 353;  MODEL_CLAUDE_4_5_SONNET_THINKING = 354;  MODEL_CLAUDE_4_5_SONNET_1M = 370;  MODEL_CLAUDE_4_5_SONNET_THINKING_1M = 371;  MODEL_CLAUDE_4_5_OPUS = 391;  MODEL_CLAUDE_4_5_OPUS_THINKING = 392;  MODEL_CLAUDE_4_SONNET_DATABRICKS = 292;  MODEL_CLAUDE_4_SONNET_THINKING_DATABRICKS = 293;  MODEL_TOGETHERAI_TEXT_EMBEDDING_M2_BERT = 81;  MODEL_TOGETHERAI_LLAMA_3_1_8B_INSTRUCT = 165;  MODEL_HUGGING_FACE_TEXT_EMBEDDING_M2_BERT = 82;  MODEL_HUGGING_FACE_TEXT_EMBEDDING_UAE_CODE = 83;  MODEL_HUGGING_FACE_TEXT_EMBEDDING_BGE = 84;  MODEL_HUGGING_FACE_TEXT_EMBEDDING_BLADE = 85;  MODEL_HUGGING_FACE_TEXT_EMBEDDING_ARCTIC_LARGE = 86;  MODEL_HUGGING_FACE_TEXT_EMBEDDING_E5_BASE = 87;  MODEL_HUGGING_FACE_TEXT_EMBEDDING_MXBAI = 88;  MODEL_LLAMA_3_1_8B_INSTRUCT = 106;  MODEL_LLAMA_3_1_70B_INSTRUCT = 107;  MODEL_LLAMA_3_1_405B_INSTRUCT = 105;  MODEL_LLAMA_3_3_70B_INSTRUCT = 208;  MODEL_LLAMA_3_3_70B_INSTRUCT_R1 = 209;  MODEL_LLAMA_3_1_70B_INSTRUCT_LONG_CONTEXT = 116;  MODEL_LLAMA_3_1_8B_HERMES_3 = 176;  MODEL_LLAMA_3_1_70B_HERMES_3 = 177;  MODEL_QWEN_2_5_7B_INSTRUCT = 178;  MODEL_QWEN_2_5_32B_INSTRUCT = 179;  MODEL_QWEN_2_5_72B_INSTRUCT = 180;  MODEL_QWEN_2_5_32B_INSTRUCT_R1 = 224;  MODEL_QWEN_3_235B_INSTRUCT = 324;  MODEL_QWEN_3_CODER_480B_INSTRUCT = 325;  MODEL_QWEN_3_CODER_480B_INSTRUCT_FAST = 327;  MODEL_GLM_4_5 = 342;  MODEL_GLM_4_5_FAST = 352;  MODEL_GLM_4_6 = 356;  MODEL_GLM_4_6_FAST = 357;  MODEL_GLM_4_7 = 417;  MODEL_GLM_4_7_FAST = 418;  MODEL_SWE_1_5 = 359;  MODEL_SWE_1_5_REDIRECT = 361;  MODEL_SWE_1_5_THINKING = 369;  MODEL_SWE_1_5_SLOW = 377;  MODEL_SWE_1_6 = 420;  MODEL_SWE_1_6_FAST = 421;  MODEL_CODEMAP_SMALL = 358;  MODEL_CODEMAP_MEDIUM = 360;  MODEL_CODEMAP_SMART = 362;  MODEL_COGNITION_INSTANT_CONTEXT = 355;  MODEL_LLAMA_FT_DEEPWIKI_ARTICLE = 335;  MODEL_LLAMA_FT_DEEPWIKI_HOVER = 336;  MODEL_LLAMA_FT_LIFEGUARD = 398;  MODEL_COGNITION_LIFEGUARD = 410;  MODEL_NOMIC_TEXT_EMBEDDING_V1 = 89;  MODEL_NOMIC_TEXT_EMBEDDING_V1_5 = 90;  MODEL_MISTRAL_7B = 77;  MODEL_SALESFORCE_EMBEDDING_2R = 99;  MODEL_CUSTOM_VLLM = 182;  MODEL_TEI_BGE_M3 = 92;  MODEL_TEI_NOMIC_EMBED_TEXT_V1 = 93;  MODEL_TEI_INTFLOAT_E5_LARGE_INSTRUCT = 94;  MODEL_TEI_SNOWFLAKE_ARCTIC_EMBED_L = 95;  MODEL_TEI_UAE_CODE_LARGE_V1 = 96;  MODEL_TEI_B1ADE = 97;  MODEL_TEI_WHEREISAI_UAE_LARGE_V1 = 98;  MODEL_TEI_WHEREISAI_UAE_CODE_LARGE_V1 = 100;  MODEL_OPENAI_COMPATIBLE = 200;  MODEL_ANTHROPIC_COMPATIBLE = 201;  MODEL_VERTEX_COMPATIBLE = 202;  MODEL_BEDROCK_COMPATIBLE = 203;  MODEL_AZURE_COMPATIBLE = 204;  MODEL_DEEPSEEK_V3 = 205;  MODEL_DEEPSEEK_R1 = 206;  MODEL_DEEPSEEK_R1_SLOW = 215;  MODEL_DEEPSEEK_R1_FAST = 216;  MODEL_KIMI_K2 = 323;  MODEL_MINIMAX_M2 = 368;  MODEL_MINIMAX_M2_1 = 419;  MODEL_DEEPSEEK_V3_2 = 409;  MODEL_KIMI_K2_THINKING = 394;  MODEL_CUSTOM_OPEN_ROUTER = 185;  MODEL_XAI_GROK_2 = 212;  MODEL_XAI_GROK_3 = 217;  MODEL_XAI_GROK_3_MINI_REASONING = 234;  MODEL_XAI_GROK_CODE_FAST = 345;  MODEL_PRIVATE_1 = 219;  MODEL_PRIVATE_2 = 220;  MODEL_PRIVATE_3 = 221;  MODEL_PRIVATE_4 = 222;  MODEL_PRIVATE_5 = 223;  MODEL_PRIVATE_6 = 314;  MODEL_PRIVATE_7 = 315;  MODEL_PRIVATE_8 = 316;  MODEL_PRIVATE_9 = 317;  MODEL_PRIVATE_10 = 318;  MODEL_PRIVATE_11 = 347;  MODEL_PRIVATE_12 = 348;  MODEL_PRIVATE_13 = 349;  MODEL_PRIVATE_14 = 350;  MODEL_PRIVATE_15 = 351;  MODEL_PRIVATE_16 = 363;  MODEL_PRIVATE_17 = 364;  MODEL_PRIVATE_18 = 365;  MODEL_PRIVATE_19 = 366;  MODEL_PRIVATE_20 = 367;  MODEL_PRIVATE_21 = 372;  MODEL_PRIVATE_22 = 373;  MODEL_PRIVATE_23 = 374;  MODEL_PRIVATE_24 = 375;  MODEL_PRIVATE_25 = 376;  MODEL_PRIVATE_26 = 380;  MODEL_PRIVATE_27 = 381;  MODEL_PRIVATE_28 = 382;  MODEL_PRIVATE_29 = 383;  MODEL_PRIVATE_30 = 384;  MODEL_GPT_5_2_NONE = 399;  MODEL_GPT_5_2_LOW = 400;  MODEL_GPT_5_2_MEDIUM = 401;  MODEL_GPT_5_2_HIGH = 402;  MODEL_GPT_5_2_XHIGH = 403;  MODEL_GPT_5_2_NONE_PRIORITY = 404;  MODEL_GPT_5_2_LOW_PRIORITY = 405;  MODEL_GPT_5_2_MEDIUM_PRIORITY = 406;  MODEL_GPT_5_2_HIGH_PRIORITY = 407;  MODEL_GPT_5_2_XHIGH_PRIORITY = 408;  MODEL_GPT_5_2_CODEX_LOW = 422;  MODEL_GPT_5_2_CODEX_MEDIUM = 423;  MODEL_GPT_5_2_CODEX_HIGH = 424;  MODEL_GPT_5_2_CODEX_XHIGH = 425;  MODEL_GPT_5_2_CODEX_LOW_PRIORITY = 426;  MODEL_GPT_5_2_CODEX_MEDIUM_PRIORITY = 427;  MODEL_GPT_5_2_CODEX_HIGH_PRIORITY = 428;  MODEL_GPT_5_2_CODEX_XHIGH_PRIORITY = 429;  MODEL_SGLANG_ROLLOUT = 600;}
+enum ExperimentKey {  UNSPECIFIED = 0;  USE_INTERNAL_CHAT_MODEL = 36;  RECORD_FILES = 47;  NO_SAMPLER_EARLY_STOP = 48;  CM_MEMORY_TELEMETRY = 53;  LANGUAGE_SERVER_VERSION = 55;  LANGUAGE_SERVER_AUTO_RELOAD = 56;  ONLY_MULTILINE = 60;  USE_AUTOCOMPLETE_MODEL = 64;  USE_ATTRIBUTION_FOR_INDIVIDUAL_TIER = 68;  CHAT_MODEL_CONFIG = 78;  COMMAND_MODEL_CONFIG = 79;  MIN_IDE_VERSION = 81;  API_SERVER_VERBOSE_ERRORS = 84;  DEFAULT_ENABLE_SEARCH = 86;  COLLECT_ONBOARDING_EVENTS = 87;  COLLECT_EXAMPLE_COMPLETIONS = 88;  USE_MULTILINE_MODEL = 89;  ATTRIBUTION_KILL_SWITCH = 92;  FAST_MULTILINE = 94;  SINGLE_COMPLETION = 95;  STOP_FIRST_NON_WHITESPACE_LINE = 96;  CORTEX_CONFIG = 102;  MODEL_CHAT_11121_VARIANTS = 103;  INCLUDE_PROMPT_COMPONENTS = 105;  NON_TEAMS_KILL_SWITCH = 106;  PERSIST_CODE_TRACKER = 108;  CHAT_COMPLETION_TOKENS_SOFT_LIMIT = 114;  CHAT_TOKENS_SOFT_LIMIT = 115;  DISABLE_COMPLETIONS_CACHE = 118;  LLAMA3_405B_KILL_SWITCH = 119;  USE_COMMAND_DOCSTRING_GENERATION = 121;  ENABLE_SUPERCOMPLETE = 123;  SENTRY = 136;  FAST_SINGLELINE = 144;  R2_LANGUAGE_SERVER_DOWNLOAD = 147;  SPLIT_MODEL = 152;  WINDSURF_SENTRY_SAMPLE_RATE = 198;  API_SERVER_CUTOFF = 158;  FAST_SPEED_KILL_SWITCH = 159;  PREDICTIVE_MULTILINE = 160;  SUPERCOMPLETE_FILTER_REVERT = 125;  SUPERCOMPLETE_FILTER_PREFIX_MATCH = 126;  SUPERCOMPLETE_FILTER_SCORE_THRESHOLD = 127;  SUPERCOMPLETE_FILTER_INSERTION_CAP = 128;  SUPERCOMPLETE_FILTER_DELETION_CAP = 133;  SUPERCOMPLETE_FILTER_WHITESPACE_ONLY = 156;  SUPERCOMPLETE_FILTER_NO_OP = 170;  SUPERCOMPLETE_FILTER_SUFFIX_MATCH = 176;  SUPERCOMPLETE_FILTER_PREVIOUSLY_SHOWN = 182;  SUPERCOMPLETE_MIN_SCORE = 129;  SUPERCOMPLETE_MAX_INSERTIONS = 130;  SUPERCOMPLETE_LINE_RADIUS = 131;  SUPERCOMPLETE_MAX_DELETIONS = 132;  SUPERCOMPLETE_RECENT_STEPS_DURATION = 138;  SUPERCOMPLETE_MAX_TRAJECTORY_STEPS = 154;  SUPERCOMPLETE_MAX_TRAJECTORY_STEP_SIZE = 203;  SUPERCOMPLETE_DISABLE_TYPING_CACHE = 231;  SUPERCOMPLETE_ALWAYS_USE_CACHE_ON_EQUAL_STATE = 293;  SUPERCOMPLETE_CACHE_ON_PARENT_ID_KILL_SWITCH = 297;  SUPERCOMPLETE_PRUNE_RESPONSE = 140;  SUPERCOMPLETE_PRUNE_MAX_INSERT_DELETE_LINE_DELTA = 141;  SUPERCOMPLETE_MODEL_CONFIG = 145;  SUPERCOMPLETE_ON_TAB = 151;  SUPERCOMPLETE_INLINE_PURE_DELETE = 171;  SUPERCOMPLETE_INLINE_RICH_GHOST_TEXT_INSERTIONS = 218;  MODEL_CHAT_19821_VARIANTS = 308;  SUPERCOMPLETE_MAX_CONCURRENT_REQUESTS = 284;  COMMAND_PROMPT_CACHE_CONFIG = 255;  CUMULATIVE_PROMPT_CONFIG = 256;  CUMULATIVE_PROMPT_CASCADE_CONFIG = 279;  TAB_JUMP_CUMULATIVE_PROMPT_CONFIG = 301;  COMPLETION_SPEED_SUPERCOMPLETE_CACHE = 207;  COMPLETION_SPEED_PREDICTIVE_SUPERCOMPLETE = 208;  COMPLETION_SPEED_TAB_JUMP_CACHE = 209;  COMPLETION_SPEED_PREDICTIVE_TAB_JUMP = 210;  COMPLETION_SPEED_BLOCK_TAB_JUMP_ON_PREDICTIVE_SUPERCOMPLETE = 294;  JETBRAINS_ENABLE_ONBOARDING = 137;  ENABLE_AUTOCOMPLETE_DURING_INTELLISENSE = 146;  COMMAND_BOX_ON_TOP = 155;  CONTEXT_ACTIVE_DOCUMENT_FRACTION = 149;  CONTEXT_FORCE_LOCAL_CONTEXT = 178;  CROSS_SELL_EXTENSION_DOWNLOAD_WINDSURF = 220;  MODEL_LLAMA_3_1_70B_INSTRUCT_LONG_CONTEXT_VARIANTS = 295;  USE_AUTOCOMPLETE_MODEL_SERVER_SIDE = 163;  SUPERCOMPLETE_NO_CONTEXT = 165;  SUPERCOMPLETE_NO_ACTIVE_NODE = 166;  TAB_JUMP_ENABLED = 168;  TAB_JUMP_ACCEPT_ENABLED = 169;  TAB_JUMP_LINE_RADIUS = 177;  TAB_JUMP_MIN_FILTER_RADIUS = 197;  TAB_JUMP_ON_ACCEPT_ONLY = 205;  TAB_JUMP_FILTER_IN_SELECTION = 215;  TAB_JUMP_MODEL_CONFIG = 237;  TAB_JUMP_FILTER_NO_OP = 238;  TAB_JUMP_FILTER_REVERT = 239;  TAB_JUMP_FILTER_SCORE_THRESHOLD = 240;  TAB_JUMP_FILTER_WHITESPACE_ONLY = 241;  TAB_JUMP_FILTER_INSERTION_CAP = 242;  TAB_JUMP_FILTER_DELETION_CAP = 243;  TAB_JUMP_PRUNE_RESPONSE = 260;  TAB_JUMP_PRUNE_MAX_INSERT_DELETE_LINE_DELTA = 261;  TAB_JUMP_STOP_TOKEN_MIDSTREAM = 317;  VIEWED_FILE_TRACKER_CONFIG = 211;  SNAPSHOT_TO_STEP_OPTIONS_OVERRIDE = 305;  STREAMING_EXTERNAL_COMMAND = 172;  USE_SPECIAL_EDIT_CODE_BLOCK = 179;  ENABLE_SUGGESTED_RESPONSES = 187;  CASCADE_BASE_MODEL_ID = 190;  CASCADE_PLAN_BASED_CONFIG_OVERRIDE = 266;  CASCADE_GLOBAL_CONFIG_OVERRIDE = 212;  CASCADE_BACKGROUND_RESEARCH_CONFIG_OVERRIDE = 193;  CASCADE_ENFORCE_QUOTA = 204;  CASCADE_ENABLE_AUTOMATED_MEMORIES = 224;  CASCADE_MEMORY_CONFIG_OVERRIDE = 314;  CASCADE_USE_REPLACE_CONTENT_EDIT_TOOL = 228;  CASCADE_VIEW_FILE_TOOL_CONFIG_OVERRIDE = 258;  CASCADE_USE_EXPERIMENT_CHECKPOINTER = 247;  CASCADE_ENABLE_CUSTOM_RECIPES = 236;  CASCADE_ENABLE_MCP_TOOLS = 245;  CASCADE_AUTO_FIX_LINTS = 275;  USE_ANTHROPIC_TOKEN_EFFICIENT_TOOLS_BETA = 296;  CASCADE_USER_MEMORIES_IN_SYS_PROMPT = 289;  CASCADE_ENABLE_PROXY_WEB_SERVER = 290;  COLLAPSE_ASSISTANT_MESSAGES = 312;  CASCADE_DEFAULT_MODEL_OVERRIDE = 321;  ENABLE_SMART_COPY = 181;  ENABLE_COMMIT_MESSAGE_GENERATION = 185;  SKIP_CONSISTENCY_MANAGER = 194;  FIREWORKS_ON_DEMAND_DEPLOYMENT = 276;  API_SERVER_CLIENT_USE_HTTP_2 = 202;  AUTOCOMPLETE_DEFAULT_DEBOUNCE_MS = 213;  AUTOCOMPLETE_FAST_DEBOUNCE_MS = 214;  PROFILING_TELEMETRY_SAMPLE_RATE = 219;  STREAM_USER_SHELL_COMMANDS = 225;  API_SERVER_PROMPT_CACHE_REPLICAS = 307;  API_SERVER_ENABLE_MORE_LOGGING = 272;  COMMAND_INJECT_USER_MEMORIES = 233;  AUTOCOMPLETE_HIDDEN_ERROR_REGEX = 234;  DISABLE_IDE_COMPLETIONS_DEBOUNCE = 278;  ENABLE_QUICK_ACTIONS = 250;  QUICK_ACTIONS_WHITELIST_REGEX = 251;  CASCADE_NEW_MODELS_NUX = 259;  CASCADE_NEW_WAVE_2_MODELS_NUX = 270;  SUPERCOMPLETE_FAST_DEBOUNCE = 262;  SUPERCOMPLETE_REGULAR_DEBOUNCE = 263;  XML_TOOL_PARSING_MODELS = 268;  SUPERCOMPLETE_DONT_FILTER_MID_STREAMED = 269;  ANNOYANCE_MANAGER_MAX_NAVIGATION_RENDERS = 285;  ANNOYANCE_MANAGER_INLINE_PREVENTION_THRESHOLD_MS = 286;  ANNOYANCE_MANAGER_INLINE_PREVENTION_MAX_INTENTIONAL_REJECTIONS = 287;  ANNOYANCE_MANAGER_INLINE_PREVENTION_MAX_AUTO_REJECTIONS = 288;  USE_CUSTOM_CHARACTER_DIFF = 292;  FORCE_NON_OPTIMIZED_DIFF = 298;  CASCADE_WEB_APP_DEPLOYMENTS_ENABLED = 300;  CASCADE_RECIPES_AT_MENTION_VISIBILITY = 316;  IMPLICIT_USES_CLIPBOARD = 310;  DISABLE_SUPERCOMPLETE_PCW = 303;  BLOCK_TAB_ON_SHOWN_AUTOCOMPLETE = 304;  CASCADE_WEB_SEARCH_NUX = 311;  MODEL_NOTIFICATIONS = 319;  MODEL_SELECTOR_NUX_COPY = 320;  CASCADE_TOOL_CALL_PRICING_NUX = 322;  CASCADE_PLUGINS_TAB = 323;  WAVE_8_RULES_ENABLED = 324;  WAVE_8_KNOWLEDGE_ENABLED = 325;  CASCADE_ONBOARDING = 326;  CASCADE_ONBOARDING_REVERT = 327;  CASCADE_WINDSURF_BROWSER_TOOLS_ENABLED = 328;  CASCADE_MODEL_HEADER_WARNING = 329;  TEST_ONLY = 999;}
+enum ExperimentSource {  EXPERIMENT_SOURCE_UNSPECIFIED = 0;  EXPERIMENT_SOURCE_EXTENSION = 1;  EXPERIMENT_SOURCE_LANGUAGE_SERVER = 2;  EXPERIMENT_SOURCE_API_SERVER = 3;}
+enum CompletionSource {  COMPLETION_SOURCE_UNSPECIFIED = 0;  COMPLETION_SOURCE_TYPING_AS_SUGGESTED = 1;  COMPLETION_SOURCE_CACHE = 2;  COMPLETION_SOURCE_NETWORK = 3;}
+enum PromptElementKind {  PROMPT_ELEMENT_KIND_UNSPECIFIED = 0;  PROMPT_ELEMENT_KIND_FILE_MARKER = 2;  PROMPT_ELEMENT_KIND_OTHER_DOCUMENT = 4;  PROMPT_ELEMENT_KIND_BEFORE_CURSOR = 5;  PROMPT_ELEMENT_KIND_AFTER_CURSOR = 7;  PROMPT_ELEMENT_KIND_FIM = 8;  PROMPT_ELEMENT_KIND_SOT = 9;  PROMPT_ELEMENT_KIND_EOT = 10;  PROMPT_ELEMENT_KIND_CODE_CONTEXT_ITEM = 13;  PROMPT_ELEMENT_KIND_INSTRUCTION = 14;  PROMPT_ELEMENT_KIND_SELECTION = 15;  PROMPT_ELEMENT_KIND_TRAJECTORY_STEP = 16;  PROMPT_ELEMENT_KIND_ACTIVE_DOCUMENT = 17;  PROMPT_ELEMENT_KIND_CACHED_MESSAGE = 18;}
+enum PromptAnnotationKind {  PROMPT_ANNOTATION_KIND_UNSPECIFIED = 0;  PROMPT_ANNOTATION_KIND_COPY = 1;  PROMPT_ANNOTATION_KIND_PROMPT_CACHE = 2;}
+enum CompletionType {  COMPLETION_TYPE_UNSPECIFIED = 0;  COMPLETION_TYPE_SINGLE = 1;  COMPLETION_TYPE_MULTI = 2;  COMPLETION_TYPE_INLINE_FIM = 3;  COMPLETION_TYPE_CASCADE = 4;}
+enum CodeSource {  CODE_SOURCE_UNSPECIFIED = 0;  CODE_SOURCE_BASE = 1;  CODE_SOURCE_CODEIUM = 2;  CODE_SOURCE_USER = 3;  CODE_SOURCE_USER_LARGE = 4;  CODE_SOURCE_UNKNOWN = 5;}
+enum ProviderSource {  PROVIDER_SOURCE_UNSPECIFIED = 0;  PROVIDER_SOURCE_AUTOCOMPLETE = 1;  PROVIDER_SOURCE_CHAT = 2;  PROVIDER_SOURCE_COMMAND_GENERATE = 4;  PROVIDER_SOURCE_COMMAND_EDIT = 5;  PROVIDER_SOURCE_SUPERCOMPLETE = 6;  PROVIDER_SOURCE_COMMAND_PLAN = 7;  PROVIDER_SOURCE_QUERY = 8;  PROVIDER_SOURCE_FAST_APPLY = 9;  PROVIDER_SOURCE_COMMAND_TERMINAL = 10;  PROVIDER_SOURCE_TAB_JUMP = 11;  PROVIDER_SOURCE_CASCADE = 12;}
+enum StatusLevel {  STATUS_LEVEL_UNSPECIFIED = 0;  STATUS_LEVEL_ERROR = 1;  STATUS_LEVEL_WARNING = 2;  STATUS_LEVEL_INFO = 3;  STATUS_LEVEL_DEBUG = 4;}
+enum ModelAlias {  MODEL_ALIAS_UNSPECIFIED = 0;  MODEL_ALIAS_CASCADE_BASE = 1;  MODEL_ALIAS_VISTA = 3;  MODEL_ALIAS_SHAMU = 4;  MODEL_ALIAS_SWE_1 = 5;  MODEL_ALIAS_SWE_1_LITE = 6;  MODEL_ALIAS_AUTO = 7;}
+enum ModelPricingType {  MODEL_PRICING_TYPE_UNSPECIFIED = 0;  MODEL_PRICING_TYPE_STATIC_CREDIT = 1;  MODEL_PRICING_TYPE_API = 2;  MODEL_PRICING_TYPE_BYOK = 3;  MODEL_PRICING_TYPE_DEVIN_ENTERPRISE = 4;}
+enum ModelProvider {  MODEL_PROVIDER_UNSPECIFIED = 0;  MODEL_PROVIDER_WINDSURF = 1;  MODEL_PROVIDER_OPENAI = 2;  MODEL_PROVIDER_ANTHROPIC = 3;  MODEL_PROVIDER_GOOGLE = 4;  MODEL_PROVIDER_XAI = 5;  MODEL_PROVIDER_DEEPSEEK = 6;  MODEL_PROVIDER_MOONSHOT = 7;  MODEL_PROVIDER_QWEN = 8;}
+enum TeamsTier {  TEAMS_TIER_UNSPECIFIED = 0;  TEAMS_TIER_TEAMS = 1;  TEAMS_TIER_PRO = 2;  TEAMS_TIER_TRIAL = 9;  TEAMS_TIER_ENTERPRISE_SAAS = 3;  TEAMS_TIER_HYBRID = 4;  TEAMS_TIER_ENTERPRISE_SELF_HOSTED = 5;  TEAMS_TIER_ENTERPRISE_SELF_SERVE = 10;  TEAMS_TIER_DEVIN_ENTERPRISE = 12;  TEAMS_TIER_WAITLIST_PRO = 6;  TEAMS_TIER_TEAMS_ULTIMATE = 7;  TEAMS_TIER_PRO_ULTIMATE = 8;  TEAMS_TIER_ENTERPRISE_SAAS_POOLED = 11;}
+enum APIProvider {  API_PROVIDER_UNSPECIFIED = 0;  API_PROVIDER_INTERNAL = 1;  API_PROVIDER_OPENAI = 2;  API_PROVIDER_GOOGLE_VERTEX = 3;  API_PROVIDER_ANTHROPIC = 4;  API_PROVIDER_VLLM = 5;  API_PROVIDER_TOGETHER_AI = 6;  API_PROVIDER_HUGGING_FACE = 7;  API_PROVIDER_NOMIC = 8;  API_PROVIDER_TEI = 9;  API_PROVIDER_OPENAI_COMPATIBLE_EXTERNAL = 10;  API_PROVIDER_ANTHROPIC_COMPATIBLE_EXTERNAL = 11;  API_PROVIDER_VERTEX_COMPATIBLE_EXTERNAL = 12;  API_PROVIDER_BEDROCK_COMPATIBLE_EXTERNAL = 13;  API_PROVIDER_AZURE_COMPATIBLE_EXTERNAL = 14;  API_PROVIDER_ANTHROPIC_BEDROCK = 15;  API_PROVIDER_FIREWORKS = 16;  API_PROVIDER_OPEN_ROUTER = 17;  API_PROVIDER_XAI = 18;  API_PROVIDER_ANTHROPIC_BYOK = 20;  API_PROVIDER_CEREBRAS = 21;  API_PROVIDER_XAI_BYOK = 22;  API_PROVIDER_GEMINI_OPENAI = 23;  API_PROVIDER_GOOGLE_GEMINI = 24;  API_PROVIDER_GOOGLE_GENAI_VERTEX = 25;  API_PROVIDER_ANTHROPIC_VERTEX = 26;  API_PROVIDER_DATABRICKS = 27;  API_PROVIDER_OPEN_ROUTER_BYOK = 28;  API_PROVIDER_ANTHROPIC_DEVIN = 29;  API_PROVIDER_FIREWORKS_DEVIN = 30;  API_PROVIDER_GROQ = 31;  API_PROVIDER_OPENAI_DEVIN = 32;  API_PROVIDER_LLAMA_FT_DEEPWIKI = 33;  API_PROVIDER_XAI_INTERNAL = 34;  API_PROVIDER_FLOODGATE = 36;  API_PROVIDER_ANTHROPIC_BEDROCK_US = 37;  API_PROVIDER_ANTHROPIC_BEDROCK_GLOBAL = 38;  API_PROVIDER_MODAL = 40;  API_PROVIDER_GOOGLE_GEMINI_DEVIN = 41;  API_PROVIDER_FIREWORKS_COGNITION = 42;  API_PROVIDER_GOOGLE_GENAI_VERTEX_GLOBAL = 43;  API_PROVIDER_ANTHROPIC_VERTEX_US = 44;  API_PROVIDER_ANTHROPIC_VERTEX_EU = 45;  API_PROVIDER_ANTHROPIC_VERTEX_GLOBAL = 46;  API_PROVIDER_FIREWORKS_COGNITION_INTERNAL = 47;  API_PROVIDER_SGLANG = 60;  API_PROVIDER_AZURE_OPENAI_FEDERATED = 61;}
+enum ModelType {  MODEL_TYPE_UNSPECIFIED = 0;  MODEL_TYPE_COMPLETION = 1;  MODEL_TYPE_CHAT = 2;  MODEL_TYPE_EMBED = 3;  MODEL_TYPE_QUERY = 4;}
+enum PromptTemplaterType {  PROMPT_TEMPLATER_TYPE_UNSPECIFIED = 0;  PROMPT_TEMPLATER_TYPE_LLAMA_2 = 1;  PROMPT_TEMPLATER_TYPE_LLAMA_3 = 2;  PROMPT_TEMPLATER_TYPE_CHATML = 3;  PROMPT_TEMPLATER_TYPE_CHAT_TRANSCRIPT = 4;  PROMPT_TEMPLATER_TYPE_DEEPSEEK_V2 = 5;  PROMPT_TEMPLATER_TYPE_DEEPSEEK_V3 = 6;  PROMPT_TEMPLATER_TYPE_KIMI = 7;}
+enum ToolFormatterType {  TOOL_FORMATTER_TYPE_UNSPECIFIED = 0;  TOOL_FORMATTER_TYPE_LLAMA_3 = 1;  TOOL_FORMATTER_TYPE_HERMES = 2;  TOOL_FORMATTER_TYPE_XML = 3;  TOOL_FORMATTER_TYPE_CHAT_TRANSCRIPT = 4;  TOOL_FORMATTER_TYPE_KIMI = 5;  TOOL_FORMATTER_TYPE_QWENCODER = 6;  TOOL_FORMATTER_TYPE_SUPERCOMPLETE = 7;}
+enum ArenaTier {  ARENA_TIER_UNSPECIFIED = 0;  ARENA_TIER_FAST = 1;  ARENA_TIER_SMART = 2;}
+enum ModelCostTier {  MODEL_COST_TIER_UNSPECIFIED = 0;  MODEL_COST_TIER_LOW = 1;  MODEL_COST_TIER_MEDIUM = 2;  MODEL_COST_TIER_HIGH = 3;}
+enum EventType {  EVENT_TYPE_UNSPECIFIED = 0;  EVENT_TYPE_ENABLE_CODEIUM = 1;  EVENT_TYPE_DISABLE_CODEIUM = 2;  EVENT_TYPE_SHOW_PREVIOUS_COMPLETION = 3;  EVENT_TYPE_SHOW_NEXT_COMPLETION = 4;  EVENT_TYPE_COPILOT_STATUS = 5;  EVENT_TYPE_COMPLETION_SUPPRESSED = 6;  EVENT_TYPE_MEMORY_STATS = 8;  EVENT_TYPE_LOCAL_CONTEXT_RELEVANCE_CHECK = 9;  EVENT_TYPE_ACTIVE_EDITOR_CHANGED = 10;  EVENT_TYPE_SHOW_PREVIOUS_CORTEX_STEP = 11;  EVENT_TYPE_SHOW_NEXT_CORTEX_STEP = 12;  EVENT_TYPE_INDEXER_STATS = 13;  EVENT_TYPE_SYSTEM_METRICS_TELEMETRY = 14;}
+enum CommandRequestSource {  COMMAND_REQUEST_SOURCE_UNSPECIFIED = 0;  COMMAND_REQUEST_SOURCE_DEFAULT = 1;  COMMAND_REQUEST_SOURCE_FUNCTION_CODE_LENS = 2;  COMMAND_REQUEST_SOURCE_CLASS_CODE_LENS = 3;  COMMAND_REQUEST_SOURCE_RIGHT_CLICK_REFACTOR = 4;  COMMAND_REQUEST_SOURCE_SELECTION_HINT_CODE_LENS = 5;  COMMAND_REQUEST_SOURCE_LINE_HINT_CODE_LENS = 6;  COMMAND_REQUEST_SOURCE_PLAN = 7;  COMMAND_REQUEST_SOURCE_FOLLOWUP = 8;  COMMAND_REQUEST_SOURCE_PASTE_AND_TRANSLATE = 9;  COMMAND_REQUEST_SOURCE_SUPERCOMPLETE = 10;  COMMAND_REQUEST_SOURCE_FUNCTION_DOCSTRING = 11;  COMMAND_REQUEST_SOURCE_FAST_APPLY = 12;  COMMAND_REQUEST_SOURCE_TERMINAL = 13;  COMMAND_REQUEST_SOURCE_TAB_JUMP = 14;}
 enum ContextSnippetType {  CONTEXT_SNIPPET_TYPE_UNSPECIFIED = 0;  CONTEXT_SNIPPET_TYPE_RAW_SOURCE = 1;  CONTEXT_SNIPPET_TYPE_SIGNATURE = 2;  CONTEXT_SNIPPET_TYPE_NODEPATH = 3;}
 enum IndexChoice {  INDEX_CHOICE_UNSPECIFIED = 0;  INDEX_CHOICE_GITHUB_BASE = 1;  INDEX_CHOICE_SLACK_BASE = 2;  INDEX_CHOICE_SLACK_AGGREGATE = 3;  INDEX_CHOICE_GOOGLE_DRIVE_BASE = 4;  INDEX_CHOICE_JIRA_BASE = 5;  INDEX_CHOICE_SCM = 6;}
 enum DocumentType {  DOCUMENT_TYPE_UNSPECIFIED = 0;  DOCUMENT_TYPE_SLACK_MESSAGE = 1;  DOCUMENT_TYPE_SLACK_CHANNEL = 2;  DOCUMENT_TYPE_GITHUB_ISSUE = 3;  DOCUMENT_TYPE_GITHUB_ISSUE_COMMENT = 4;  DOCUMENT_TYPE_GITHUB_REPO = 8;  DOCUMENT_TYPE_GOOGLE_DRIVE_FILE = 5;  DOCUMENT_TYPE_GOOGLE_DRIVE_FOLDER = 6;  DOCUMENT_TYPE_JIRA_ISSUE = 7;  DOCUMENT_TYPE_CCI = 9;}
 enum CascadeCommandsAutoExecution {  CASCADE_COMMANDS_AUTO_EXECUTION_UNSPECIFIED = 0;  CASCADE_COMMANDS_AUTO_EXECUTION_OFF = 1;  CASCADE_COMMANDS_AUTO_EXECUTION_AUTO = 2;  CASCADE_COMMANDS_AUTO_EXECUTION_EAGER = 3;  CASCADE_COMMANDS_AUTO_EXECUTION_DISABLED = 4;}
-enum RefreshCustomizationType {  REFRESH_CUSTOMIZATION_TYPE_UNSPECIFIED = 0;  REFRESH_CUSTOMIZATION_TYPE_RULE = 1;  REFRESH_CUSTOMIZATION_TYPE_WORKFLOW = 2;}
-enum ProductEventType {  EVENT_UNSPECIFIED = 0;  WINDSURF_EDITOR_READY = 251;  WINDSURF_EXTENSION_START = 253;  WINDSURF_EXTENSION_ACTIVATED = 32;  LS_DOWNLOAD_START = 1;  LS_DOWNLOAD_COMPLETE = 2;  LS_DOWNLOAD_FAILURE = 5;  LS_BINARY_STARTUP = 250;  LS_STARTUP = 3;  LS_FAILURE = 4;  AUTOCOMPLETE_ACCEPTED = 6;  AUTOCOMPLETE_ONE_WORD_ACCEPTED = 7;  CHAT_MESSAGE_SENT = 8;  CHAT_MENTION_INSERT = 13;  CHAT_MENTION_MENU_OPEN = 19;  CHAT_OPEN_SETTINGS = 14;  CHAT_OPEN_CONTEXT_SETTINGS = 15;  CHAT_WITH_CODEBASE = 16;  CHAT_NEW_CONVERSATION = 17;  CHAT_CHANGE_MODEL = 18;  CHAT_TOGGLE_FOCUS_INSERT_TEXT = 34;  FUNCTION_REFACTOR = 28;  EXPLAIN_CODE_BLOCK = 29;  FUNCTION_ADD_DOCSTRING = 30;  EXPLAIN_PROBLEM = 31;  COMMAND_BOX_OPENED = 9;  COMMAND_SUBMITTED = 10;  COMMAND_ACCEPTED = 11;  COMMAND_REJECTED = 12;  WS_ONBOARDING_LANDING_PAGE_OPENED = 20;  WS_ONBOARDING_SETUP_PAGE_OPENED = 21;  WS_ONBOARDING_KEYBINDINGS_PAGE_OPENED = 22;  WS_ONBOARDING_MIGRATION_SCOPE_PAGE_OPENED = 23;  WS_ONBOARDING_IMPORT_PAGE_OPENED = 24;  WS_ONBOARDING_AUTH_PAGE_OPENED = 25;  WS_ONBOARDING_AUTH_MANUAL_PAGE_OPENED = 26;  WS_ONBOARDING_CHOOSE_THEME_PAGE_OPENED = 35;  WS_ONBOARDING_COMPLETED = 27;  WS_SKIPPED_ONBOARDING = 69;  WS_SETTINGS_PAGE_OPEN = 72;  WS_SETTINGS_PAGE_OPEN_WITH_SETTING_FOCUS = 73;  EMPTY_WORKSPACE_PAGE_OPENED = 209;  EMPTY_WORKSPACE_PAGE_RECENT_FOLDERS_CLICKED = 210;  EMPTY_WORKSPACE_PAGE_OPEN_FOLDER_CLICKED = 211;  EMPTY_WORKSPACE_PAGE_GENERATE_PROJECT_CLICKED = 212;  PROVIDE_FEEDBACK = 33;  CASCADE_MESSAGE_SENT = 36;  WS_OPEN_CASCADE_MEMORIES_PANEL = 38;  PROVIDE_MESSAGE_FEEDBACK = 41;  CASCADE_MEMORY_DELETED = 42;  CASCADE_STEP_COMPLETED = 43;  ACKNOWLEDGE_CASCADE_CODE_EDIT = 44;  CASCADE_WEB_TOOLS_OPEN_READ_URL_MARKDOWN = 45;  CASCADE_WEB_TOOLS_OPEN_CHUNK_MARKDOWN = 46;  CASCADE_MCP_SERVER_INIT = 64;  CASCADE_KNOWLEDGE_BASE_ITEM_OPENED = 113;  CASCADE_VIEW_LOADED = 119;  CASCADE_CONTEXT_SCOPE_ITEM_ATTACHED = 173;  CASCADE_CLICK_EVENT = 65;  CASCADE_IMPRESSION_EVENT = 67;  OPEN_CHANGELOG = 37;  CURSOR_DETECTED = 39;  VSCODE_DETECTED = 40;  JETBRAINS_DETECTED = 153;  CROSS_SELL_EXTENSION_DOWNLOAD_WINDSURF_CLICK = 47;  CROSS_SELL_EXTENSION_DOWNLOAD_WINDSURF_NUDGE_IMPRESSION = 48;  WS_PROBLEMS_TAB_SEND_ALL_TO_CASCADE = 49;  WS_PROBLEMS_TAB_SEND_ALL_IN_FILE_TO_CASCADE = 50;  WS_CASCADE_BAR_FILE_NAV = 51;  WS_CASCADE_BAR_HUNK_NAV = 52;  WS_CASCADE_BAR_ACCEPT_FILE = 53;  WS_CASCADE_BAR_REJECT_FILE = 54;  WS_CUSTOM_APP_ICON_MODAL_OPEN = 55;  WS_CUSTOM_APP_ICON_SELECT_CLASSIC = 56;  WS_CUSTOM_APP_ICON_SELECT_CLASSIC_LIGHT = 57;  WS_CUSTOM_APP_ICON_SELECT_RETRO = 58;  WS_CUSTOM_APP_ICON_SELECT_BLUEPRINT = 59;  WS_CUSTOM_APP_ICON_SELECT_HAND_DRAWN = 60;  WS_CUSTOM_APP_ICON_SELECT_SUNSET = 61;  WS_CUSTOM_APP_ICON_SELECT_VALENTINE = 66;  WS_CUSTOM_APP_ICON_SELECT_PIXEL_SURF = 82;  ENTERED_MCP_TOOLBAR_TAB = 63;  CLICKED_TO_CONFIGURE_MCP = 62;  WS_SETTINGS_UPDATED = 68;  BROWSER_PREVIEW_DOM_ELEMENT = 70;  BROWSER_PREVIEW_CONSOLE_OUTPUT = 71;  WS_SETTINGS_CHANGED_BY_USER = 74;  WS_GENERATE_COMMIT_MESSAGE_CLICKED = 75;  WS_GENERATE_COMMIT_MESSAGE_ERRORED = 76;  WS_CLICKED_COMMIT_FROM_SCM_PANEL = 77;  WS_CANCELED_GENERATE_COMMIT_MESSAGE = 79;  USING_DEV_EXTENSION = 78;  WS_APP_DEPLOYMENT_CREATE_PROJECT = 80;  WS_APP_DEPLOYMENT_DEPLOY_PROJECT = 81;  CASCADE_OPEN_ACTIVE_CONVERSATION_DROPDOWN = 114;  CASCADE_SELECT_ACTIVE_CONVERSATION_ON_DROPDOWN = 115;  CASCADE_NAVIGATE_ACTIVE_CONVERSATION_ON_DROPDOWN = 122;  CASCADE_SNOOZE_CONVERSATION_ON_DROPDOWN = 123;  CASCADE_TOGGLE_NOTIFICATION_ON_DROPDOWN = 124;  CASCADE_SELECT_NOTIFICATION_ON_DROPDOWN = 125;  CASCADE_NAVIGATE_NOTIFICATION_ON_DROPDOWN = 126;  CASCADE_DISMISS_NOTIFICATION_ON_DROPDOWN = 127;  CASCADE_TRAJECTORY_SHARE_COPY_LINK = 137;  CASCADE_TRAJECTORY_SHARE_CREATE_LINK = 138;  CASCADE_CUSTOMIZATIONS_TAB_CHANGE = 139;  CASCADE_WORKFLOW_OPEN = 140;  CASCADE_NEW_WORKFLOW_CLICKED = 141;  CASCADE_NEW_GLOBAL_WORKFLOW_CLICKED = 184;  CASCADE_WORKFLOW_REFRESH_CLICKED = 142;  CASCADE_RULE_OPEN = 143;  CASCADE_NEW_RULE_CLICKED = 144;  CASCADE_NEW_GLOBAL_RULE_CLICKED = 145;  CASCADE_RULE_REFRESH_CLICKED = 146;  CASCADE_IMPORT_RULES_FROM_CURSOR_CLICKED = 147;  WS_IMPORT_CURSOR_RULES_COMMAND_PALETTE = 152;  CASCADE_CHANGES_ACCEPT_ALL = 83;  CASCADE_CHANGES_REJECT_ALL = 84;  CASCADE_MEMORIES_EDIT = 85;  CASCADE_MEMORIES_VIEW = 86;  KEYBOARD_SHORTCUT = 136;  CASCADE_INSERT_AT_MENTION = 87;  CASCADE_ERROR_STEP = 120;  CASCADE_SUGGESTED_RESPONSES_SUGGESTION_CLICKED = 121;  CASCADE_PLUGIN_PANEL_OPENED = 128;  CASCADE_PLUGIN_PAGE_OPENED = 129;  CASCADE_PLUGIN_INSTALLED = 130;  CASCADE_PLUGIN_DISABLED = 131;  CASCADE_PLUGIN_ENABLED = 132;  CASCADE_PLUGIN_INSTALLATION_ERROR = 133;  CASCADE_PLUGIN_TOOL_ENABLED = 134;  CASCADE_PLUGIN_TOOL_DISABLED = 135;  WEBSITE_NOT_FOUND_PAGE = 88;  WEBSITE_AUTH_REDIRECT_LONG_WAIT = 89;  WEBSITE_AUTH_REDIRECT_ERROR = 90;  WEBSITE_AUTH_REDIRECT_SUCCESS = 112;  WEBSITE_PAGE_VISIT = 175;  WEBSITE_SIGNUP_INFO = 176;  WEBSITE_START_PLAN_CHECKOUT = 177;  WEBSITE_START_UPDATE_PAYMENT = 202;  WEBSITE_START_VIEW_INVOICES = 203;  WEBSITE_UNIVERSITY_LECTURE_VIEW = 214;  WEBSITE_DISALLOW_ENTERPRISE_LOGIN = 224;  WEBSITE_SSO_LOGIN_REDIRECT = 225;  WEBSITE_ATTEMPT_TO_LOGIN = 226;  WEBSITE_SUCCESSFUL_LOGIN = 227;  WEBSITE_FAILED_LOGIN = 228;  JB_OPEN_PLAN_INFO = 91;  JB_SNOOZE_PLUGIN = 92;  JB_TOGGLE_PLUGIN_STATUS = 93;  JB_SWITCH_CHANNEL = 94;  JB_OPEN_SETTINGS = 95;  JB_PLUGIN_LOG_IN = 96;  JB_PLUGIN_LOG_OUT = 97;  JB_OPEN_QUICK_REFERENCE = 98;  JB_EDIT_KEYBOARD_SHORTCUTS = 99;  JB_CASCADE_BAR_CASCADE_ICON = 100;  JB_CASCADE_BAR_FILE_NAV = 101;  JB_CASCADE_BAR_HUNK_NAV = 102;  JB_CASCADE_BAR_ACCEPT_FILE = 103;  JB_CASCADE_BAR_REJECT_FILE = 104;  JB_INLAY_HUNK_ACCEPT = 105;  JB_INLAY_HUNK_REJECT = 106;  JB_DIFF_RE_RENDER = 107;  JB_ONBOARDING_OPENED = 108;  JB_ONBOARDING_COMPLETED = 109;  JB_ONBOARDING_SKIPPED = 110;  JB_ONBOARDING_LEARN_MORE = 111;  JB_DIFF_RESOLUTION_ERRORED = 116;  JB_ACKNOWLEDGE_CODE_EDIT_ERRORED = 117;  JB_OPEN_SETTINGS_NOTIFICATION = 118;  JB_MCP_ADD_SERVER = 148;  JB_MCP_SAVE_CONFIG = 149;  JB_MCP_EXPAND_TOOLS = 150;  JB_DISABLE_AUTOGEN_MEMORY = 151;  JB_TOGGLE_AUTOCOMPLETE = 154;  JB_LOGIN_MANUAL_AUTH_TOKEN = 174;  JB_AUTO_UPDATED = 179;  JB_DRAG_DROP_FILE = 182;  JB_AUTO_OPEN_CHAT_WINDOW = 183;  WS_TERMINAL_INTEGRATION_FORCE_EXIT = 155;  KNOWLEDGE_BASE_ITEM_CREATED = 156;  KNOWLEDGE_BASE_ITEM_EDITED = 157;  KNOWLEDGE_BASE_ITEM_DELETED = 158;  KNOWLEDGE_BASE_ITEM_READ = 159;  KNOWLEDGE_BASE_CONNECTION_CREATE = 160;  KNOWLEDGE_BASE_CONNECTION_REMOVE = 161;  TEAM_CONFIG_TOGGLE_AUTO_RUN_COMMANDS = 162;  TEAM_CONFIG_TOGGLE_MCP_SERVERS = 163;  TEAM_CONFIG_TOGGLE_APP_DEPLOYMENTS = 164;  TEAM_CONFIG_TOGGLE_SANDBOX_APP_DEPLOYMENTS = 165;  TEAM_CONFIG_TOGGLE_TEAMS_APP_DEPLOYMENTS = 166;  TEAM_CONFIG_TOGGLE_GITHUB_REVIEWS = 167;  TEAM_CONFIG_TOGGLE_GITHUB_DESCRIPTION_EDITS = 168;  TEAM_CONFIG_TOGGLE_PR_REVIEW_GUIDELINES = 169;  TEAM_CONFIG_TOGGLE_PR_DESCRIPTION_GUIDELINES = 170;  TEAM_CONFIG_TOGGLE_INDIVIDUAL_LEVEL_ANALYTICS = 171;  TEAM_CONFIG_TOGGLE_CONVERSATION_SHARING = 172;  TEAM_CONFIG_UPDATE_MCP_SERVERS = 178;  TEAM_CONFIG_TOGGLE_GITHUB_AUTO_REVIEWS = 207;  TEAM_CONFIG_UPDATE_TOP_UP_SETTINGS = 213;  BROWSER_OPEN = 180;  CASCADE_WEB_TOOLS_OPEN_BROWSER_MARKDOWN = 181;  BROWSER_PAGE_LOAD_SUCCESS = 206;  BROWSER_TOOLBAR_INSERT_PAGE_MENTION = 208;  BROWSER_INSERT_TEXT_CONTENT = 215;  BROWSER_INSERT_SCREENSHOT = 216;  BROWSER_INSERT_CODE_BLOCK = 217;  BROWSER_INSERT_LOG_BLOCK = 218;  BROWSER_INSERT_CONSOLE_OUTPUT = 219;  BROWSER_INSERT_DOM_ELEMENT = 220;  SUPERCOMPLETE_REQUEST_STARTED = 195;  SUPERCOMPLETE_CACHE_HIT = 196;  SUPERCOMPLETE_ERROR_GETTING_RESPONSE = 197;  SUPERCOMPLETE_NO_RESPONSE = 185;  SUPERCOMPLETE_REQUEST_SUCCEEDED = 186;  SUPERCOMPLETE_FILTERED = 187;  TAB_JUMP_REQUEST_STARTED = 188;  TAB_JUMP_CACHE_HIT = 189;  TAB_JUMP_ERROR_GETTING_RESPONSE = 190;  TAB_JUMP_NO_RESPONSE = 191;  TAB_JUMP_PROCESSING_COMPLETE = 192;  TAB_JUMP_FILTERED = 193;  TAB_JUMP_ERROR_UI_RENDERED = 194;  AUTO_CASCADE_PR_TITLE_GENERATED = 198;  AUTO_CASCADE_PR_DESCRIPTION_GENERATED = 199;  AUTO_CASCADE_PR_REVIEW_REQUESTED = 200;  AUTO_CASCADE_PR_REVIEW_GENERATED = 201;  AUTO_CASCADE_GITHUB_CONNECTION_ADDED = 204;  AUTO_CASCADE_GITHUB_CONNECTION_REMOVED = 205;  AUTOCOMPLETE_CHAT_NO_RESPONSE = 221;  AUTOCOMPLETE_CHAT_ERROR_GETTING_RESPONSE = 222;  AUTOCOMPLETE_CHAT_REQUEST_ACCEPTED = 223;}
-enum AuthSource {  AUTH_SOURCE_CODEIUM = 0;  AUTH_SOURCE_DEEPNOTE = 1;  AUTH_SOURCE_CODESANDBOX = 2;  AUTH_SOURCE_STACKBLITZ = 3;  AUTH_SOURCE_VALTOWN = 4;  AUTH_SOURCE_HEX = 5;  AUTH_SOURCE_ZAPIER = 6;  AUTH_SOURCE_SUPERBLOCKS = 7;  AUTH_SOURCE_EMBARCADERO = 8;}
-enum TerminalShellCommandSource {  TERMINAL_SHELL_COMMAND_SOURCE_UNSPECIFIED = 0;  TERMINAL_SHELL_COMMAND_SOURCE_USER = 1;  TERMINAL_SHELL_COMMAND_SOURCE_CASCADE = 2;}
-enum Model {  MODEL_UNSPECIFIED = 0;  MODEL_EMBED_6591 = 20;  MODEL_8341 = 33;  MODEL_8528 = 42;  MODEL_9024 = 41;  MODEL_14602 = 112;  MODEL_15133 = 115;  MODEL_15302 = 119;  MODEL_15335 = 121;  MODEL_15336 = 122;  MODEL_15931 = 167;  MODEL_QUERY_9905 = 48;  MODEL_QUERY_11791 = 66;  MODEL_CHAT_11120 = 57;  MODEL_CHAT_11121 = 58;  MODEL_CHAT_12119 = 70;  MODEL_CHAT_12121 = 69;  MODEL_CHAT_12437 = 74;  MODEL_CHAT_12491 = 76;  MODEL_CHAT_12623 = 78;  MODEL_CHAT_12950 = 79;  MODEL_CHAT_12968 = 101;  MODEL_CHAT_13404 = 102;  MODEL_CHAT_13566 = 103;  MODEL_CHAT_13930 = 108;  MODEL_CHAT_14255 = 110;  MODEL_CHAT_14256 = 111;  MODEL_CHAT_14942 = 114;  MODEL_CHAT_15305 = 120;  MODEL_CHAT_15600 = 123;  MODEL_CHAT_16801 = 124;  MODEL_CHAT_16718 = 175;  MODEL_CHAT_15729 = 168;  MODEL_CHAT_16579 = 173;  MODEL_CHAT_16579_CRUSOE = 174;  MODEL_CHAT_18805 = 181;  MODEL_CHAT_18468 = 210;  MODEL_CHAT_19484 = 233;  MODEL_CHAT_20706 = 235;  MODEL_CHAT_21779 = 245;  MODEL_CHAT_19040 = 211;  MODEL_CHAT_19820 = 229;  MODEL_CHAT_19821 = 230;  MODEL_CHAT_19821_CRUSOE = 244;  MODEL_CHAT_23310 = 269;  MODEL_CHAT_28580 = 330;  MODEL_CHAT_28581 = 331;  MODEL_CHAT_28582 = 332;  MODEL_CHAT_28583 = 333;  MODEL_CHAT_28584 = 334;  MODEL_CHAT_19822 = 231;  MODEL_CHAT_22798 = 255;  MODEL_CHAT_22799 = 256;  MODEL_CHAT_22800 = 257;  MODEL_CHAT_23151 = 267;  MODEL_CHAT_23152 = 268;  MODEL_CASCADE_22893 = 270;  MODEL_CASCADE_20064 = 225;  MODEL_CASCADE_20065 = 236;  MODEL_CASCADE_20066 = 237;  MODEL_CASCADE_20067 = 238;  MODEL_CASCADE_20068 = 239;  MODEL_CASCADE_20069 = 240;  MODEL_CASCADE_20070 = 250;  MODEL_CASCADE_20071 = 251;  MODEL_CASCADE_20072 = 252;  MODEL_CASCADE_20073 = 253;  MODEL_CASCADE_20074 = 254;  MODEL_CASCADE_20075 = 307;  MODEL_CASCADE_20076 = 308;  MODEL_CASCADE_20077 = 309;  MODEL_CASCADE_20078 = 310;  MODEL_CASCADE_20079 = 311;  MODEL_CASCADE_20080 = 297;  MODEL_CASCADE_20081 = 298;  MODEL_CASCADE_20082 = 299;  MODEL_CASCADE_20083 = 300;  MODEL_CASCADE_20084 = 301;  MODEL_CASCADE_20085 = 302;  MODEL_CASCADE_20086 = 303;  MODEL_CASCADE_20087 = 304;  MODEL_CASCADE_20088 = 305;  MODEL_CASCADE_20089 = 306;  MODEL_DEEPSEEK_V3_INTERNAL = 247;  MODEL_DEEPSEEK_V3_0324_INTERNAL = 248;  MODEL_DEEPSEEK_R1_INTERNAL = 249;  MODEL_ANTHROPIC_WINDSURF_RESEARCH = 241;  MODEL_ANTHROPIC_WINDSURF_RESEARCH_THINKING = 242;  MODEL_DRAFT_11408 = 65;  MODEL_DRAFT_CHAT_11883 = 67;  MODEL_DRAFT_CHAT_12196 = 72;  MODEL_DRAFT_CHAT_12413 = 73;  MODEL_DRAFT_CHAT_13175 = 104;  MODEL_DRAFT_CHAT_19823 = 232;  MODEL_DRAFT_CHAT_20707 = 243;  MODEL_DRAFT_CHAT_22801 = 258;  MODEL_DRAFT_CHAT_23508 = 273;  MODEL_DRAFT_CASCADE_23672 = 274;  MODEL_CHAT_3_5_TURBO = 28;  MODEL_CHAT_GPT_4 = 30;  MODEL_CHAT_GPT_4_1106_PREVIEW = 37;  MODEL_TEXT_EMBEDDING_OPENAI_ADA = 91;  MODEL_TEXT_EMBEDDING_OPENAI_3_SMALL = 163;  MODEL_TEXT_EMBEDDING_OPENAI_3_LARGE = 164;  MODEL_CHAT_GPT_4O_2024_05_13 = 71;  MODEL_CHAT_GPT_4O_2024_08_06 = 109;  MODEL_CHAT_GPT_4O_MINI_2024_07_18 = 113;  MODEL_CHAT_GPT_4_1_2025_04_14 = 259;  MODEL_CHAT_GPT_4_1_MINI_2025_04_14 = 260;  MODEL_CHAT_GPT_4_1_NANO_2025_04_14 = 261;  MODEL_CHAT_O1_PREVIEW = 117;  MODEL_CHAT_O1_MINI = 118;  MODEL_CHAT_O1 = 170;  MODEL_CHAT_O3_MINI = 207;  MODEL_CHAT_O3_MINI_LOW = 213;  MODEL_CHAT_O3_MINI_HIGH = 214;  MODEL_CHAT_O3 = 218;  MODEL_CHAT_O3_LOW = 262;  MODEL_CHAT_O3_HIGH = 263;  MODEL_CHAT_O4_MINI = 264;  MODEL_CHAT_O4_MINI_LOW = 265;  MODEL_CHAT_O4_MINI_HIGH = 266;  MODEL_CHAT_GPT_4_5 = 228;  MODEL_CODEX_MINI_LATEST = 287;  MODEL_CODEX_MINI_LATEST_LOW = 288;  MODEL_CODEX_MINI_LATEST_HIGH = 289;  MODEL_O3_PRO_2025_06_10 = 294;  MODEL_O3_PRO_2025_06_10_LOW = 295;  MODEL_O3_PRO_2025_06_10_HIGH = 296;  MODEL_GPT_OSS_120B = 326;  MODEL_GPT_5_NANO = 337;  MODEL_CHAT_GPT_5_MINIMAL = 338;  MODEL_CHAT_GPT_5_LOW = 339;  MODEL_CHAT_GPT_5 = 340;  MODEL_CHAT_GPT_5_HIGH = 341;  MODEL_CHAT_GPT_5_CODEX = 346;  MODEL_GOOGLE_GEMINI_1_0_PRO = 61;  MODEL_GOOGLE_GEMINI_1_5_PRO = 62;  MODEL_GOOGLE_GEMINI_EXP_1206 = 183;  MODEL_GOOGLE_GEMINI_2_0_FLASH = 184;  MODEL_GOOGLE_GEMINI_2_5_PRO = 246;  MODEL_GOOGLE_GEMINI_2_5_FLASH_PREVIEW_04_17 = 272;  MODEL_GOOGLE_GEMINI_2_5_FLASH_PREVIEW_05_20 = 275;  MODEL_GOOGLE_GEMINI_2_5_FLASH_PREVIEW_05_20_THINKING = 276;  MODEL_GOOGLE_GEMINI_2_5_FLASH = 312;  MODEL_GOOGLE_GEMINI_2_5_FLASH_THINKING = 313;  MODEL_GOOGLE_GEMINI_2_5_FLASH_LITE = 343;  MODEL_CLAUDE_CODE = 344;  MODEL_CLAUDE_3_OPUS_20240229 = 63;  MODEL_CLAUDE_3_SONNET_20240229 = 64;  MODEL_CLAUDE_3_HAIKU_20240307 = 172;  MODEL_CLAUDE_3_5_HAIKU_20241022 = 171;  MODEL_CLAUDE_3_5_SONNET_20240620 = 80;  MODEL_CLAUDE_3_5_SONNET_20241022 = 166;  MODEL_CLAUDE_3_7_SONNET_20250219 = 226;  MODEL_CLAUDE_3_7_SONNET_20250219_THINKING = 227;  MODEL_CLAUDE_3_5_SONNET_BYOK = 284;  MODEL_CLAUDE_3_7_SONNET_BYOK = 285;  MODEL_CLAUDE_3_7_SONNET_OPEN_ROUTER_BYOK = 319;  MODEL_CLAUDE_3_7_SONNET_THINKING_BYOK = 286;  MODEL_CLAUDE_3_7_SONNET_THINKING_OPEN_ROUTER_BYOK = 320;  MODEL_CLAUDE_4_OPUS_BYOK = 277;  MODEL_CLAUDE_4_OPUS_THINKING_BYOK = 278;  MODEL_CLAUDE_4_OPUS = 290;  MODEL_CLAUDE_4_OPUS_THINKING = 291;  MODEL_CLAUDE_4_SONNET_BYOK = 279;  MODEL_CLAUDE_4_SONNET_OPEN_ROUTER_BYOK = 321;  MODEL_CLAUDE_4_SONNET_THINKING_BYOK = 280;  MODEL_CLAUDE_4_SONNET_THINKING_OPEN_ROUTER_BYOK = 322;  MODEL_CLAUDE_4_SONNET = 281;  MODEL_CLAUDE_4_SONNET_THINKING = 282;  MODEL_CLAUDE_4_1_OPUS = 328;  MODEL_CLAUDE_4_1_OPUS_THINKING = 329;  MODEL_CLAUDE_4_SONNET_DATABRICKS = 292;  MODEL_CLAUDE_4_SONNET_THINKING_DATABRICKS = 293;  MODEL_TOGETHERAI_TEXT_EMBEDDING_M2_BERT = 81;  MODEL_TOGETHERAI_LLAMA_3_1_8B_INSTRUCT = 165;  MODEL_HUGGING_FACE_TEXT_EMBEDDING_M2_BERT = 82;  MODEL_HUGGING_FACE_TEXT_EMBEDDING_UAE_CODE = 83;  MODEL_HUGGING_FACE_TEXT_EMBEDDING_BGE = 84;  MODEL_HUGGING_FACE_TEXT_EMBEDDING_BLADE = 85;  MODEL_HUGGING_FACE_TEXT_EMBEDDING_ARCTIC_LARGE = 86;  MODEL_HUGGING_FACE_TEXT_EMBEDDING_E5_BASE = 87;  MODEL_HUGGING_FACE_TEXT_EMBEDDING_MXBAI = 88;  MODEL_LLAMA_3_1_8B_INSTRUCT = 106;  MODEL_LLAMA_3_1_70B_INSTRUCT = 107;  MODEL_LLAMA_3_1_405B_INSTRUCT = 105;  MODEL_LLAMA_3_3_70B_INSTRUCT = 208;  MODEL_LLAMA_3_3_70B_INSTRUCT_R1 = 209;  MODEL_LLAMA_3_1_70B_INSTRUCT_LONG_CONTEXT = 116;  MODEL_LLAMA_3_1_8B_HERMES_3 = 176;  MODEL_LLAMA_3_1_70B_HERMES_3 = 177;  MODEL_QWEN_2_5_7B_INSTRUCT = 178;  MODEL_QWEN_2_5_32B_INSTRUCT = 179;  MODEL_QWEN_2_5_72B_INSTRUCT = 180;  MODEL_QWEN_2_5_32B_INSTRUCT_R1 = 224;  MODEL_QWEN_3_235B_INSTRUCT = 324;  MODEL_QWEN_3_CODER_480B_INSTRUCT = 325;  MODEL_QWEN_3_CODER_480B_INSTRUCT_FAST = 327;  MODEL_GLM_4_5 = 342;  MODEL_LLAMA_FT_DEEPWIKI_ARTICLE = 335;  MODEL_LLAMA_FT_DEEPWIKI_HOVER = 336;  MODEL_NOMIC_TEXT_EMBEDDING_V1 = 89;  MODEL_NOMIC_TEXT_EMBEDDING_V1_5 = 90;  MODEL_MISTRAL_7B = 77;  MODEL_SALESFORCE_EMBEDDING_2R = 99;  MODEL_CUSTOM_VLLM = 182;  MODEL_TEI_BGE_M3 = 92;  MODEL_TEI_NOMIC_EMBED_TEXT_V1 = 93;  MODEL_TEI_INTFLOAT_E5_LARGE_INSTRUCT = 94;  MODEL_TEI_SNOWFLAKE_ARCTIC_EMBED_L = 95;  MODEL_TEI_UAE_CODE_LARGE_V1 = 96;  MODEL_TEI_B1ADE = 97;  MODEL_TEI_WHEREISAI_UAE_LARGE_V1 = 98;  MODEL_TEI_WHEREISAI_UAE_CODE_LARGE_V1 = 100;  MODEL_OPENAI_COMPATIBLE = 200;  MODEL_ANTHROPIC_COMPATIBLE = 201;  MODEL_VERTEX_COMPATIBLE = 202;  MODEL_BEDROCK_COMPATIBLE = 203;  MODEL_AZURE_COMPATIBLE = 204;  MODEL_DEEPSEEK_V3 = 205;  MODEL_DEEPSEEK_R1 = 206;  MODEL_DEEPSEEK_R1_SLOW = 215;  MODEL_DEEPSEEK_R1_FAST = 216;  MODEL_KIMI_K2 = 323;  MODEL_CUSTOM_OPEN_ROUTER = 185;  MODEL_XAI_GROK_2 = 212;  MODEL_XAI_GROK_3 = 217;  MODEL_XAI_GROK_3_MINI_REASONING = 234;  MODEL_XAI_GROK_CODE_FAST = 345;  MODEL_PRIVATE_1 = 219;  MODEL_PRIVATE_2 = 220;  MODEL_PRIVATE_3 = 221;  MODEL_PRIVATE_4 = 222;  MODEL_PRIVATE_5 = 223;  MODEL_PRIVATE_6 = 314;  MODEL_PRIVATE_7 = 315;  MODEL_PRIVATE_8 = 316;  MODEL_PRIVATE_9 = 317;  MODEL_PRIVATE_10 = 318;}
-enum APIProvider {  API_PROVIDER_UNSPECIFIED = 0;  API_PROVIDER_INTERNAL = 1;  API_PROVIDER_OPENAI = 2;  API_PROVIDER_GOOGLE_VERTEX = 3;  API_PROVIDER_ANTHROPIC = 4;  API_PROVIDER_VLLM = 5;  API_PROVIDER_TOGETHER_AI = 6;  API_PROVIDER_HUGGING_FACE = 7;  API_PROVIDER_NOMIC = 8;  API_PROVIDER_TEI = 9;  API_PROVIDER_OPENAI_COMPATIBLE_EXTERNAL = 10;  API_PROVIDER_ANTHROPIC_COMPATIBLE_EXTERNAL = 11;  API_PROVIDER_VERTEX_COMPATIBLE_EXTERNAL = 12;  API_PROVIDER_BEDROCK_COMPATIBLE_EXTERNAL = 13;  API_PROVIDER_AZURE_COMPATIBLE_EXTERNAL = 14;  API_PROVIDER_ANTHROPIC_BEDROCK = 15;  API_PROVIDER_FIREWORKS = 16;  API_PROVIDER_OPEN_ROUTER = 17;  API_PROVIDER_XAI = 18;  API_PROVIDER_ANTHROPIC_BYOK = 20;  API_PROVIDER_CEREBRAS = 21;  API_PROVIDER_XAI_BYOK = 22;  API_PROVIDER_GEMINI_OPENAI = 23;  API_PROVIDER_GOOGLE_GEMINI = 24;  API_PROVIDER_GOOGLE_GENAI_VERTEX = 25;  API_PROVIDER_ANTHROPIC_VERTEX = 26;  API_PROVIDER_DATABRICKS = 27;  API_PROVIDER_OPEN_ROUTER_BYOK = 28;  API_PROVIDER_ANTHROPIC_DEVIN = 29;  API_PROVIDER_FIREWORKS_DEVIN = 30;  API_PROVIDER_GROQ = 31;  API_PROVIDER_OPENAI_DEVIN = 32;  API_PROVIDER_LLAMA_FT_DEEPWIKI = 33;  API_PROVIDER_XAI_INTERNAL = 34;  API_PROVIDER_CEREBRAS_CACHE = 35;}
-enum ModelAlias {  MODEL_ALIAS_UNSPECIFIED = 0;  MODEL_ALIAS_CASCADE_BASE = 1;  MODEL_ALIAS_VISTA = 3;  MODEL_ALIAS_SHAMU = 4;  MODEL_ALIAS_SWE_1 = 5;  MODEL_ALIAS_SWE_1_LITE = 6;  MODEL_ALIAS_AUTO = 7;}
+enum SupercompleteTriggerCondition {  SUPERCOMPLETE_TRIGGER_CONDITION_UNSPECIFIED = 0;  SUPERCOMPLETE_TRIGGER_CONDITION_AUTOCOMPLETE_ACCEPT = 1;  SUPERCOMPLETE_TRIGGER_CONDITION_CURSOR_LINE_NAVIGATION = 2;  SUPERCOMPLETE_TRIGGER_CONDITION_TYPING = 3;  SUPERCOMPLETE_TRIGGER_CONDITION_FORCED = 4;  SUPERCOMPLETE_TRIGGER_CONDITION_TAB_JUMP_ACCEPT = 5;  SUPERCOMPLETE_TRIGGER_CONDITION_SUPERCOMPLETE_ACCEPT = 6;  SUPERCOMPLETE_TRIGGER_CONDITION_TAB_JUMP_PREDICTIVE = 7;  SUPERCOMPLETE_TRIGGER_CONDITION_AUTOCOMPLETE_PREDICTIVE = 8;  SUPERCOMPLETE_TRIGGER_CONDITION_SUPERCOMPLETE_PREDICTIVE = 9;  SUPERCOMPLETE_TRIGGER_CONDITION_TAB_JUMP_EDIT = 10;}
+enum ConversationalPlannerMode {  CONVERSATIONAL_PLANNER_MODE_UNSPECIFIED = 0;  CONVERSATIONAL_PLANNER_MODE_DEFAULT = 1;  CONVERSATIONAL_PLANNER_MODE_READ_ONLY = 2;  CONVERSATIONAL_PLANNER_MODE_NO_TOOL = 3;  CONVERSATIONAL_PLANNER_MODE_EXPLORE = 4;  CONVERSATIONAL_PLANNER_MODE_PLANNING = 5;  CONVERSATIONAL_PLANNER_MODE_AUTO = 6;}
 enum DeploymentProvider {  DEPLOYMENT_PROVIDER_UNSPECIFIED = 0;  DEPLOYMENT_PROVIDER_VERCEL = 1;  DEPLOYMENT_PROVIDER_NETLIFY = 2;  DEPLOYMENT_PROVIDER_CLOUDFLARE = 3;}
 enum CodeContextSource {  CODE_CONTEXT_SOURCE_UNSPECIFIED = 0;  CODE_CONTEXT_SOURCE_OPEN_DOCS = 1;  CODE_CONTEXT_SOURCE_SEARCH_RESULT = 2;  CODE_CONTEXT_SOURCE_IMPORT = 3;  CODE_CONTEXT_SOURCE_LOCAL_DIRECTORY = 4;  CODE_CONTEXT_SOURCE_LAST_ACTIVE_DOC = 5;  CODE_CONTEXT_SOURCE_ORACLE_ITEMS = 6;  CODE_CONTEXT_SOURCE_PINNED_CONTEXT = 7;  CODE_CONTEXT_SOURCE_RESEARCH_STATE = 8;  CODE_CONTEXT_SOURCE_GROUND_TRUTH_PLAN_EDIT = 9;  CODE_CONTEXT_SOURCE_COMMIT_GRAPH = 10;}
 enum MarkdownNodeType {  MARKDOWN_NODE_TYPE_UNSPECIFIED = 0;  MARKDOWN_NODE_TYPE_HEADER_1 = 1;  MARKDOWN_NODE_TYPE_HEADER_2 = 2;  MARKDOWN_NODE_TYPE_HEADER_3 = 3;  MARKDOWN_NODE_TYPE_HEADER_4 = 4;  MARKDOWN_NODE_TYPE_HEADER_5 = 5;  MARKDOWN_NODE_TYPE_HEADER_6 = 6;}
 enum ThirdPartyWebSearchProvider {  THIRD_PARTY_WEB_SEARCH_PROVIDER_UNSPECIFIED = 0;  THIRD_PARTY_WEB_SEARCH_PROVIDER_OPENAI = 1;}
 enum ThirdPartyWebSearchModel {  THIRD_PARTY_WEB_SEARCH_MODEL_UNSPECIFIED = 0;  THIRD_PARTY_WEB_SEARCH_MODEL_O3 = 1;  THIRD_PARTY_WEB_SEARCH_MODEL_GPT_4_1 = 2;  THIRD_PARTY_WEB_SEARCH_MODEL_O4_MINI = 3;}
-enum ConversationalPlannerMode {  CONVERSATIONAL_PLANNER_MODE_UNSPECIFIED = 0;  CONVERSATIONAL_PLANNER_MODE_DEFAULT = 1;  CONVERSATIONAL_PLANNER_MODE_READ_ONLY = 2;  CONVERSATIONAL_PLANNER_MODE_NO_TOOL = 3;}
-enum CascadeRunExtensionCodeAutoRun {  CASCADE_RUN_EXTENSION_CODE_AUTO_RUN_UNSPECIFIED = 0;  CASCADE_RUN_EXTENSION_CODE_AUTO_RUN_ENABLED = 1;  CASCADE_RUN_EXTENSION_CODE_AUTO_RUN_DISABLED = 2;  CASCADE_RUN_EXTENSION_CODE_AUTO_RUN_MODEL_DECIDES = 3;}
-enum ChatMessageSource {  CHAT_MESSAGE_SOURCE_UNSPECIFIED = 0;  CHAT_MESSAGE_SOURCE_USER = 1;  CHAT_MESSAGE_SOURCE_SYSTEM = 2;  CHAT_MESSAGE_SOURCE_UNKNOWN = 3;  CHAT_MESSAGE_SOURCE_TOOL = 4;  CHAT_MESSAGE_SOURCE_SYSTEM_PROMPT = 5;}
-enum PromptAnnotationKind {  PROMPT_ANNOTATION_KIND_UNSPECIFIED = 0;  PROMPT_ANNOTATION_KIND_COPY = 1;  PROMPT_ANNOTATION_KIND_PROMPT_CACHE = 2;}
+enum CascadeWebRequestsAutoExecution {  CASCADE_WEB_REQUESTS_AUTO_EXECUTION_UNSPECIFIED = 0;  CASCADE_WEB_REQUESTS_AUTO_EXECUTION_DISABLED = 1;  CASCADE_WEB_REQUESTS_AUTO_EXECUTION_ALLOWLIST = 2;  CASCADE_WEB_REQUESTS_AUTO_EXECUTION_TURBO = 3;}
 enum DeploymentBuildStatus {  DEPLOYMENT_BUILD_STATUS_UNSPECIFIED = 0;  DEPLOYMENT_BUILD_STATUS_QUEUED = 1;  DEPLOYMENT_BUILD_STATUS_INITIALIZING = 2;  DEPLOYMENT_BUILD_STATUS_BUILDING = 3;  DEPLOYMENT_BUILD_STATUS_ERROR = 4;  DEPLOYMENT_BUILD_STATUS_READY = 5;  DEPLOYMENT_BUILD_STATUS_CANCELED = 6;}
-enum StopReason {  STOP_REASON_UNSPECIFIED = 0;  STOP_REASON_INCOMPLETE = 1;  STOP_REASON_STOP_PATTERN = 2;  STOP_REASON_MAX_TOKENS = 3;  STOP_REASON_MIN_LOG_PROB = 4;  STOP_REASON_MAX_NEWLINES = 5;  STOP_REASON_EXIT_SCOPE = 6;  STOP_REASON_NONFINITE_LOGIT_OR_PROB = 7;  STOP_REASON_FIRST_NON_WHITESPACE_LINE = 8;  STOP_REASON_PARTIAL = 9;  STOP_REASON_FUNCTION_CALL = 10;  STOP_REASON_CONTENT_FILTER = 11;  STOP_REASON_NON_INSERTION = 12;  STOP_REASON_ERROR = 13;}
-enum FilterReason {  FILTER_REASON_NONE = 0;  FILTER_REASON_INCOMPLETE = 1;  FILTER_REASON_EMPTY = 2;  FILTER_REASON_REPETITIVE = 3;  FILTER_REASON_DUPLICATE = 4;  FILTER_REASON_LONG_LINE = 5;  FILTER_REASON_COMPLETIONS_CUTOFF = 6;  FILTER_REASON_ATTRIBUTION = 7;  FILTER_REASON_NON_MATCHING = 8;  FILTER_REASON_NON_INSERTION = 9;}
-enum ExperimentKey {  UNSPECIFIED = 0;  USE_INTERNAL_CHAT_MODEL = 36;  RECORD_FILES = 47;  NO_SAMPLER_EARLY_STOP = 48;  CM_MEMORY_TELEMETRY = 53;  LANGUAGE_SERVER_VERSION = 55;  LANGUAGE_SERVER_AUTO_RELOAD = 56;  ONLY_MULTILINE = 60;  USE_AUTOCOMPLETE_MODEL = 64;  USE_ATTRIBUTION_FOR_INDIVIDUAL_TIER = 68;  CHAT_MODEL_CONFIG = 78;  COMMAND_MODEL_CONFIG = 79;  MIN_IDE_VERSION = 81;  API_SERVER_VERBOSE_ERRORS = 84;  DEFAULT_ENABLE_SEARCH = 86;  COLLECT_ONBOARDING_EVENTS = 87;  COLLECT_EXAMPLE_COMPLETIONS = 88;  USE_MULTILINE_MODEL = 89;  ATTRIBUTION_KILL_SWITCH = 92;  FAST_MULTILINE = 94;  SINGLE_COMPLETION = 95;  STOP_FIRST_NON_WHITESPACE_LINE = 96;  CORTEX_CONFIG = 102;  MODEL_CHAT_11121_VARIANTS = 103;  INCLUDE_PROMPT_COMPONENTS = 105;  NON_TEAMS_KILL_SWITCH = 106;  PERSIST_CODE_TRACKER = 108;  API_SERVER_LIVENESS_PROBE = 112;  CHAT_COMPLETION_TOKENS_SOFT_LIMIT = 114;  CHAT_TOKENS_SOFT_LIMIT = 115;  DISABLE_COMPLETIONS_CACHE = 118;  LLAMA3_405B_KILL_SWITCH = 119;  USE_COMMAND_DOCSTRING_GENERATION = 121;  ENABLE_SUPERCOMPLETE = 123;  SENTRY = 136;  FAST_SINGLELINE = 144;  R2_LANGUAGE_SERVER_DOWNLOAD = 147;  SPLIT_MODEL = 152;  WINDSURF_SENTRY_SAMPLE_RATE = 198;  API_SERVER_CUTOFF = 158;  FAST_SPEED_KILL_SWITCH = 159;  PREDICTIVE_MULTILINE = 160;  SUPERCOMPLETE_FILTER_REVERT = 125;  SUPERCOMPLETE_FILTER_PREFIX_MATCH = 126;  SUPERCOMPLETE_FILTER_SCORE_THRESHOLD = 127;  SUPERCOMPLETE_FILTER_INSERTION_CAP = 128;  SUPERCOMPLETE_FILTER_DELETION_CAP = 133;  SUPERCOMPLETE_FILTER_WHITESPACE_ONLY = 156;  SUPERCOMPLETE_FILTER_NO_OP = 170;  SUPERCOMPLETE_FILTER_SUFFIX_MATCH = 176;  SUPERCOMPLETE_FILTER_PREVIOUSLY_SHOWN = 182;  SUPERCOMPLETE_MIN_SCORE = 129;  SUPERCOMPLETE_MAX_INSERTIONS = 130;  SUPERCOMPLETE_LINE_RADIUS = 131;  SUPERCOMPLETE_MAX_DELETIONS = 132;  SUPERCOMPLETE_RECENT_STEPS_DURATION = 138;  SUPERCOMPLETE_MAX_TRAJECTORY_STEPS = 154;  SUPERCOMPLETE_MAX_TRAJECTORY_STEP_SIZE = 203;  SUPERCOMPLETE_DISABLE_TYPING_CACHE = 231;  SUPERCOMPLETE_ALWAYS_USE_CACHE_ON_EQUAL_STATE = 293;  SUPERCOMPLETE_CACHE_ON_PARENT_ID_KILL_SWITCH = 297;  SUPERCOMPLETE_PRUNE_RESPONSE = 140;  SUPERCOMPLETE_PRUNE_MAX_INSERT_DELETE_LINE_DELTA = 141;  SUPERCOMPLETE_MODEL_CONFIG = 145;  SUPERCOMPLETE_ON_TAB = 151;  SUPERCOMPLETE_INLINE_PURE_DELETE = 171;  SUPERCOMPLETE_INLINE_RICH_GHOST_TEXT_INSERTIONS = 218;  MODEL_CHAT_19821_VARIANTS = 308;  SUPERCOMPLETE_MAX_CONCURRENT_REQUESTS = 284;  COMMAND_PROMPT_CACHE_CONFIG = 255;  CUMULATIVE_PROMPT_CONFIG = 256;  CUMULATIVE_PROMPT_CASCADE_CONFIG = 279;  TAB_JUMP_CUMULATIVE_PROMPT_CONFIG = 301;  COMPLETION_SPEED_SUPERCOMPLETE_CACHE = 207;  COMPLETION_SPEED_PREDICTIVE_SUPERCOMPLETE = 208;  COMPLETION_SPEED_TAB_JUMP_CACHE = 209;  COMPLETION_SPEED_PREDICTIVE_TAB_JUMP = 210;  COMPLETION_SPEED_BLOCK_TAB_JUMP_ON_PREDICTIVE_SUPERCOMPLETE = 294;  JETBRAINS_ENABLE_ONBOARDING = 137;  ENABLE_AUTOCOMPLETE_DURING_INTELLISENSE = 146;  COMMAND_BOX_ON_TOP = 155;  CONTEXT_ACTIVE_DOCUMENT_FRACTION = 149;  CONTEXT_FORCE_LOCAL_CONTEXT = 178;  CROSS_SELL_EXTENSION_DOWNLOAD_WINDSURF = 220;  MODEL_LLAMA_3_1_70B_INSTRUCT_LONG_CONTEXT_VARIANTS = 295;  USE_AUTOCOMPLETE_MODEL_SERVER_SIDE = 163;  SUPERCOMPLETE_NO_CONTEXT = 165;  SUPERCOMPLETE_NO_ACTIVE_NODE = 166;  TAB_JUMP_ENABLED = 168;  TAB_JUMP_ACCEPT_ENABLED = 169;  TAB_JUMP_LINE_RADIUS = 177;  TAB_JUMP_MIN_FILTER_RADIUS = 197;  TAB_JUMP_ON_ACCEPT_ONLY = 205;  TAB_JUMP_FILTER_IN_SELECTION = 215;  TAB_JUMP_MODEL_CONFIG = 237;  TAB_JUMP_FILTER_NO_OP = 238;  TAB_JUMP_FILTER_REVERT = 239;  TAB_JUMP_FILTER_SCORE_THRESHOLD = 240;  TAB_JUMP_FILTER_WHITESPACE_ONLY = 241;  TAB_JUMP_FILTER_INSERTION_CAP = 242;  TAB_JUMP_FILTER_DELETION_CAP = 243;  TAB_JUMP_PRUNE_RESPONSE = 260;  TAB_JUMP_PRUNE_MAX_INSERT_DELETE_LINE_DELTA = 261;  TAB_JUMP_STOP_TOKEN_MIDSTREAM = 317;  VIEWED_FILE_TRACKER_CONFIG = 211;  SNAPSHOT_TO_STEP_OPTIONS_OVERRIDE = 305;  STREAMING_EXTERNAL_COMMAND = 172;  USE_SPECIAL_EDIT_CODE_BLOCK = 179;  ENABLE_SUGGESTED_RESPONSES = 187;  CASCADE_BASE_MODEL_ID = 190;  CASCADE_PLAN_BASED_CONFIG_OVERRIDE = 266;  CASCADE_GLOBAL_CONFIG_OVERRIDE = 212;  CASCADE_BACKGROUND_RESEARCH_CONFIG_OVERRIDE = 193;  CASCADE_ENFORCE_QUOTA = 204;  CASCADE_ENABLE_AUTOMATED_MEMORIES = 224;  CASCADE_MEMORY_CONFIG_OVERRIDE = 314;  CASCADE_USE_REPLACE_CONTENT_EDIT_TOOL = 228;  CASCADE_VIEW_FILE_TOOL_CONFIG_OVERRIDE = 258;  CASCADE_USE_EXPERIMENT_CHECKPOINTER = 247;  CASCADE_ENABLE_CUSTOM_RECIPES = 236;  CASCADE_ENABLE_MCP_TOOLS = 245;  CASCADE_AUTO_FIX_LINTS = 275;  USE_ANTHROPIC_TOKEN_EFFICIENT_TOOLS_BETA = 296;  CASCADE_USER_MEMORIES_IN_SYS_PROMPT = 289;  CASCADE_ENABLE_PROXY_WEB_SERVER = 290;  COLLAPSE_ASSISTANT_MESSAGES = 312;  CASCADE_DEFAULT_MODEL_OVERRIDE = 321;  ENABLE_SMART_COPY = 181;  ENABLE_COMMIT_MESSAGE_GENERATION = 185;  SKIP_CONSISTENCY_MANAGER = 194;  FIREWORKS_ON_DEMAND_DEPLOYMENT = 276;  API_SERVER_CLIENT_USE_HTTP_2 = 202;  AUTOCOMPLETE_DEFAULT_DEBOUNCE_MS = 213;  AUTOCOMPLETE_FAST_DEBOUNCE_MS = 214;  PROFILING_TELEMETRY_SAMPLE_RATE = 219;  STREAM_USER_SHELL_COMMANDS = 225;  API_SERVER_PROMPT_CACHE_REPLICAS = 307;  API_SERVER_ENABLE_MORE_LOGGING = 272;  COMMAND_INJECT_USER_MEMORIES = 233;  AUTOCOMPLETE_HIDDEN_ERROR_REGEX = 234;  DISABLE_IDE_COMPLETIONS_DEBOUNCE = 278;  ENABLE_QUICK_ACTIONS = 250;  QUICK_ACTIONS_WHITELIST_REGEX = 251;  CASCADE_NEW_MODELS_NUX = 259;  CASCADE_NEW_WAVE_2_MODELS_NUX = 270;  SUPERCOMPLETE_FAST_DEBOUNCE = 262;  SUPERCOMPLETE_REGULAR_DEBOUNCE = 263;  XML_TOOL_PARSING_MODELS = 268;  SUPERCOMPLETE_DONT_FILTER_MID_STREAMED = 269;  ANNOYANCE_MANAGER_MAX_NAVIGATION_RENDERS = 285;  ANNOYANCE_MANAGER_INLINE_PREVENTION_THRESHOLD_MS = 286;  ANNOYANCE_MANAGER_INLINE_PREVENTION_MAX_INTENTIONAL_REJECTIONS = 287;  ANNOYANCE_MANAGER_INLINE_PREVENTION_MAX_AUTO_REJECTIONS = 288;  USE_CUSTOM_CHARACTER_DIFF = 292;  FORCE_NON_OPTIMIZED_DIFF = 298;  CASCADE_WEB_APP_DEPLOYMENTS_ENABLED = 300;  CASCADE_RECIPES_AT_MENTION_VISIBILITY = 316;  IMPLICIT_USES_CLIPBOARD = 310;  DISABLE_SUPERCOMPLETE_PCW = 303;  BLOCK_TAB_ON_SHOWN_AUTOCOMPLETE = 304;  CASCADE_WEB_SEARCH_NUX = 311;  MODEL_NOTIFICATIONS = 319;  MODEL_SELECTOR_NUX_COPY = 320;  CASCADE_TOOL_CALL_PRICING_NUX = 322;  CASCADE_PLUGINS_TAB = 323;  WAVE_8_RULES_ENABLED = 324;  WAVE_8_KNOWLEDGE_ENABLED = 325;  CASCADE_ONBOARDING = 326;  CASCADE_ONBOARDING_REVERT = 327;  CASCADE_WINDSURF_BROWSER_TOOLS_ENABLED = 328;  CASCADE_MODEL_HEADER_WARNING = 329;  TEST_ONLY = 999;}
-enum ExperimentSource {  EXPERIMENT_SOURCE_UNSPECIFIED = 0;  EXPERIMENT_SOURCE_EXTENSION = 1;  EXPERIMENT_SOURCE_LANGUAGE_SERVER = 2;  EXPERIMENT_SOURCE_API_SERVER = 3;}
-enum CompletionSource {  COMPLETION_SOURCE_UNSPECIFIED = 0;  COMPLETION_SOURCE_TYPING_AS_SUGGESTED = 1;  COMPLETION_SOURCE_CACHE = 2;  COMPLETION_SOURCE_NETWORK = 3;}
-enum PromptElementKind {  PROMPT_ELEMENT_KIND_UNSPECIFIED = 0;  PROMPT_ELEMENT_KIND_FILE_MARKER = 2;  PROMPT_ELEMENT_KIND_OTHER_DOCUMENT = 4;  PROMPT_ELEMENT_KIND_BEFORE_CURSOR = 5;  PROMPT_ELEMENT_KIND_AFTER_CURSOR = 7;  PROMPT_ELEMENT_KIND_FIM = 8;  PROMPT_ELEMENT_KIND_SOT = 9;  PROMPT_ELEMENT_KIND_EOT = 10;  PROMPT_ELEMENT_KIND_CODE_CONTEXT_ITEM = 13;  PROMPT_ELEMENT_KIND_INSTRUCTION = 14;  PROMPT_ELEMENT_KIND_SELECTION = 15;  PROMPT_ELEMENT_KIND_TRAJECTORY_STEP = 16;  PROMPT_ELEMENT_KIND_ACTIVE_DOCUMENT = 17;  PROMPT_ELEMENT_KIND_CACHED_MESSAGE = 18;}
-enum CompletionType {  COMPLETION_TYPE_UNSPECIFIED = 0;  COMPLETION_TYPE_SINGLE = 1;  COMPLETION_TYPE_MULTI = 2;  COMPLETION_TYPE_INLINE_FIM = 3;  COMPLETION_TYPE_CASCADE = 4;}
-enum CodeSource {  CODE_SOURCE_UNSPECIFIED = 0;  CODE_SOURCE_BASE = 1;  CODE_SOURCE_CODEIUM = 2;  CODE_SOURCE_USER = 3;  CODE_SOURCE_USER_LARGE = 4;  CODE_SOURCE_UNKNOWN = 5;}
-enum ProviderSource {  PROVIDER_SOURCE_UNSPECIFIED = 0;  PROVIDER_SOURCE_AUTOCOMPLETE = 1;  PROVIDER_SOURCE_CHAT = 2;  PROVIDER_SOURCE_COMMAND_GENERATE = 4;  PROVIDER_SOURCE_COMMAND_EDIT = 5;  PROVIDER_SOURCE_SUPERCOMPLETE = 6;  PROVIDER_SOURCE_COMMAND_PLAN = 7;  PROVIDER_SOURCE_QUERY = 8;  PROVIDER_SOURCE_FAST_APPLY = 9;  PROVIDER_SOURCE_COMMAND_TERMINAL = 10;  PROVIDER_SOURCE_TAB_JUMP = 11;  PROVIDER_SOURCE_CASCADE = 12;}
-enum StatusLevel {  STATUS_LEVEL_UNSPECIFIED = 0;  STATUS_LEVEL_ERROR = 1;  STATUS_LEVEL_WARNING = 2;  STATUS_LEVEL_INFO = 3;  STATUS_LEVEL_DEBUG = 4;}
-enum ModelPricingType {  MODEL_PRICING_TYPE_UNSPECIFIED = 0;  MODEL_PRICING_TYPE_STATIC_CREDIT = 1;  MODEL_PRICING_TYPE_API = 2;  MODEL_PRICING_TYPE_BYOK = 3;}
-enum ModelProvider {  MODEL_PROVIDER_UNSPECIFIED = 0;  MODEL_PROVIDER_WINDSURF = 1;  MODEL_PROVIDER_OPENAI = 2;  MODEL_PROVIDER_ANTHROPIC = 3;  MODEL_PROVIDER_GOOGLE = 4;  MODEL_PROVIDER_XAI = 5;  MODEL_PROVIDER_DEEPSEEK = 6;  MODEL_PROVIDER_MOONSHOT = 7;  MODEL_PROVIDER_QWEN = 8;}
-enum TeamsTier {  TEAMS_TIER_UNSPECIFIED = 0;  TEAMS_TIER_TEAMS = 1;  TEAMS_TIER_PRO = 2;  TEAMS_TIER_TRIAL = 9;  TEAMS_TIER_ENTERPRISE_SAAS = 3;  TEAMS_TIER_HYBRID = 4;  TEAMS_TIER_ENTERPRISE_SELF_HOSTED = 5;  TEAMS_TIER_ENTERPRISE_SELF_SERVE = 10;  TEAMS_TIER_WAITLIST_PRO = 6;  TEAMS_TIER_TEAMS_ULTIMATE = 7;  TEAMS_TIER_PRO_ULTIMATE = 8;}
-enum EventType {  EVENT_TYPE_UNSPECIFIED = 0;  EVENT_TYPE_ENABLE_CODEIUM = 1;  EVENT_TYPE_DISABLE_CODEIUM = 2;  EVENT_TYPE_SHOW_PREVIOUS_COMPLETION = 3;  EVENT_TYPE_SHOW_NEXT_COMPLETION = 4;  EVENT_TYPE_COPILOT_STATUS = 5;  EVENT_TYPE_COMPLETION_SUPPRESSED = 6;  EVENT_TYPE_MEMORY_STATS = 8;  EVENT_TYPE_LOCAL_CONTEXT_RELEVANCE_CHECK = 9;  EVENT_TYPE_ACTIVE_EDITOR_CHANGED = 10;  EVENT_TYPE_SHOW_PREVIOUS_CORTEX_STEP = 11;  EVENT_TYPE_SHOW_NEXT_CORTEX_STEP = 12;  EVENT_TYPE_INDEXER_STATS = 13;}
-enum EmbedType {  EMBED_TYPE_UNSPECIFIED = 0;  EMBED_TYPE_RAW_SOURCE = 1;  EMBED_TYPE_DOCSTRING = 2;  EMBED_TYPE_FUNCTION = 3;  EMBED_TYPE_NODEPATH = 4;  EMBED_TYPE_DECLARATION = 5;  EMBED_TYPE_NAIVE_CHUNK = 6;  EMBED_TYPE_SIGNATURE = 7;}
-enum CommandRequestSource {  COMMAND_REQUEST_SOURCE_UNSPECIFIED = 0;  COMMAND_REQUEST_SOURCE_DEFAULT = 1;  COMMAND_REQUEST_SOURCE_FUNCTION_CODE_LENS = 2;  COMMAND_REQUEST_SOURCE_CLASS_CODE_LENS = 3;  COMMAND_REQUEST_SOURCE_RIGHT_CLICK_REFACTOR = 4;  COMMAND_REQUEST_SOURCE_SELECTION_HINT_CODE_LENS = 5;  COMMAND_REQUEST_SOURCE_LINE_HINT_CODE_LENS = 6;  COMMAND_REQUEST_SOURCE_PLAN = 7;  COMMAND_REQUEST_SOURCE_FOLLOWUP = 8;  COMMAND_REQUEST_SOURCE_PASTE_AND_TRANSLATE = 9;  COMMAND_REQUEST_SOURCE_SUPERCOMPLETE = 10;  COMMAND_REQUEST_SOURCE_FUNCTION_DOCSTRING = 11;  COMMAND_REQUEST_SOURCE_FAST_APPLY = 12;  COMMAND_REQUEST_SOURCE_TERMINAL = 13;  COMMAND_REQUEST_SOURCE_TAB_JUMP = 14;}
-enum SupercompleteTriggerCondition {  SUPERCOMPLETE_TRIGGER_CONDITION_UNSPECIFIED = 0;  SUPERCOMPLETE_TRIGGER_CONDITION_AUTOCOMPLETE_ACCEPT = 1;  SUPERCOMPLETE_TRIGGER_CONDITION_CURSOR_LINE_NAVIGATION = 2;  SUPERCOMPLETE_TRIGGER_CONDITION_TYPING = 3;  SUPERCOMPLETE_TRIGGER_CONDITION_FORCED = 4;  SUPERCOMPLETE_TRIGGER_CONDITION_TAB_JUMP_ACCEPT = 5;  SUPERCOMPLETE_TRIGGER_CONDITION_SUPERCOMPLETE_ACCEPT = 6;  SUPERCOMPLETE_TRIGGER_CONDITION_TAB_JUMP_PREDICTIVE = 7;  SUPERCOMPLETE_TRIGGER_CONDITION_AUTOCOMPLETE_PREDICTIVE = 8;  SUPERCOMPLETE_TRIGGER_CONDITION_SUPERCOMPLETE_PREDICTIVE = 9;  SUPERCOMPLETE_TRIGGER_CONDITION_TAB_JUMP_EDIT = 10;}
+enum ChatMessageSource {  CHAT_MESSAGE_SOURCE_UNSPECIFIED = 0;  CHAT_MESSAGE_SOURCE_USER = 1;  CHAT_MESSAGE_SOURCE_SYSTEM = 2;  CHAT_MESSAGE_SOURCE_UNKNOWN = 3;  CHAT_MESSAGE_SOURCE_TOOL = 4;  CHAT_MESSAGE_SOURCE_SYSTEM_PROMPT = 5;}
 enum ValidationStatus {  VALIDATION_STATUS_UNSPECIFIED = 0;  VALIDATION_STATUS_AVAILABLE = 1;  VALIDATION_STATUS_IN_USE = 2;  VALIDATION_STATUS_TAKEN = 3;  VALIDATION_STATUS_INVALID = 4;}
-enum ContextScopeType {  CONTEXT_SCOPE_TYPE_UNSPECIFIED = 0;  CONTEXT_SCOPE_TYPE_FILE = 1;  CONTEXT_SCOPE_TYPE_DIRECTORY = 2;  CONTEXT_SCOPE_TYPE_REPOSITORY = 3;  CONTEXT_SCOPE_TYPE_CODE_CONTEXT = 4;  CONTEXT_SCOPE_TYPE_CCI_WITH_SUBRANGE = 5;  CONTEXT_SCOPE_TYPE_REPOSITORY_PATH = 6;  CONTEXT_SCOPE_TYPE_SLACK = 7;  CONTEXT_SCOPE_TYPE_GITHUB = 8;  CONTEXT_SCOPE_TYPE_FILE_LINE_RANGE = 9;  CONTEXT_SCOPE_TYPE_TEXT_BLOCK = 10;  CONTEXT_SCOPE_TYPE_JIRA = 11;  CONTEXT_SCOPE_TYPE_GOOGLE_DRIVE = 12;  CONTEXT_SCOPE_TYPE_CONSOLE_LOG = 13;  CONTEXT_SCOPE_TYPE_DOM_ELEMENT = 14;  CONTEXT_SCOPE_TYPE_RECIPE = 15;  CONTEXT_SCOPE_TYPE_KNOWLEDGE = 16;  CONTEXT_SCOPE_TYPE_RULE = 17;  CONTEXT_SCOPE_TYPE_MCP_RESOURCE = 18;  CONTEXT_SCOPE_TYPE_BROWSER_PAGE = 19;  CONTEXT_SCOPE_TYPE_BROWSER_CODE_BLOCK = 20;  CONTEXT_SCOPE_TYPE_BROWSER_TEXT = 21;  CONTEXT_SCOPE_TYPE_CONVERSATION = 22;  CONTEXT_SCOPE_TYPE_USER_ACTIVITY = 23;  CONTEXT_SCOPE_TYPE_TERMINAL = 24;  CONTEXT_SCOPE_TYPE_GITHUB_PULL_REQUEST = 25;}
+enum ContextScopeType {  CONTEXT_SCOPE_TYPE_UNSPECIFIED = 0;  CONTEXT_SCOPE_TYPE_FILE = 1;  CONTEXT_SCOPE_TYPE_DIRECTORY = 2;  CONTEXT_SCOPE_TYPE_REPOSITORY = 3;  CONTEXT_SCOPE_TYPE_CODE_CONTEXT = 4;  CONTEXT_SCOPE_TYPE_CCI_WITH_SUBRANGE = 5;  CONTEXT_SCOPE_TYPE_REPOSITORY_PATH = 6;  CONTEXT_SCOPE_TYPE_SLACK = 7;  CONTEXT_SCOPE_TYPE_GITHUB = 8;  CONTEXT_SCOPE_TYPE_FILE_LINE_RANGE = 9;  CONTEXT_SCOPE_TYPE_TEXT_BLOCK = 10;  CONTEXT_SCOPE_TYPE_JIRA = 11;  CONTEXT_SCOPE_TYPE_GOOGLE_DRIVE = 12;  CONTEXT_SCOPE_TYPE_CONSOLE_LOG = 13;  CONTEXT_SCOPE_TYPE_DOM_ELEMENT = 14;  CONTEXT_SCOPE_TYPE_RECIPE = 15;  CONTEXT_SCOPE_TYPE_KNOWLEDGE = 16;  CONTEXT_SCOPE_TYPE_RULE = 17;  CONTEXT_SCOPE_TYPE_MCP_RESOURCE = 18;  CONTEXT_SCOPE_TYPE_BROWSER_PAGE = 19;  CONTEXT_SCOPE_TYPE_BROWSER_CODE_BLOCK = 20;  CONTEXT_SCOPE_TYPE_BROWSER_TEXT = 21;  CONTEXT_SCOPE_TYPE_CONVERSATION = 22;  CONTEXT_SCOPE_TYPE_USER_ACTIVITY = 23;  CONTEXT_SCOPE_TYPE_TERMINAL = 24;  CONTEXT_SCOPE_TYPE_GITHUB_PULL_REQUEST = 25;  CONTEXT_SCOPE_TYPE_CODE_MAP = 26;  CONTEXT_SCOPE_TYPE_MCP_PROMPT = 27;  CONTEXT_SCOPE_TYPE_SKILL = 28;  CONTEXT_SCOPE_TYPE_PLAN_FILE = 29;  CONTEXT_SCOPE_TYPE_GIT = 30;}
 enum ContextInclusionType {  CONTEXT_INCLUSION_TYPE_UNSPECIFIED = 0;  CONTEXT_INCLUSION_TYPE_INCLUDE = 1;  CONTEXT_INCLUSION_TYPE_EXCLUDE = 2;}
 enum DeepWikiModelType {  DEEP_WIKI_MODEL_TYPE_UNSPECIFIED = 0;  DEEP_WIKI_MODEL_TYPE_CAPACITY_FALLBACK = 1;  DEEP_WIKI_MODEL_TYPE_LITE_FREE = 2;  DEEP_WIKI_MODEL_TYPE_LITE_PAID = 3;  DEEP_WIKI_MODEL_TYPE_PREMIUM = 4;}
 enum ScmType {  SCM_TYPE_UNSPECIFIED = 0;  SCM_TYPE_GIT = 1;  SCM_TYPE_PERFORCE = 2;}
@@ -1129,22 +1220,20 @@ enum FontSize {  FONT_SIZE_UNSPECIFIED = 0;  FONT_SIZE_SMALL = 1;  FONT_SIZE_DEF
 enum RememberLastModelSelection {  REMEMBER_LAST_MODEL_SELECTION_UNSPECIFIED = 0;  REMEMBER_LAST_MODEL_SELECTION_ENABLED = 1;  REMEMBER_LAST_MODEL_SELECTION_DISABLED = 2;}
 enum AutocompleteSpeed {  AUTOCOMPLETE_SPEED_UNSPECIFIED = 0;  AUTOCOMPLETE_SPEED_SLOW = 1;  AUTOCOMPLETE_SPEED_DEFAULT = 2;  AUTOCOMPLETE_SPEED_FAST = 3;}
 enum CascadeNUXEvent {  CASCADE_NUX_EVENT_UNSPECIFIED = 0;  CASCADE_NUX_EVENT_DIFF_OVERVIEW = 1;  CASCADE_NUX_EVENT_WEB_SEARCH = 2;  CASCADE_NUX_EVENT_NEW_MODELS_WAVE2 = 3;  CASCADE_NUX_EVENT_TOOL_CALL = 4;  CASCADE_NUX_EVENT_MODEL_SELECTOR_NUX = 5;  CASCADE_NUX_EVENT_TOOL_CALL_PRICING_NUX = 6;  CASCADE_NUX_EVENT_WRITE_CHAT_MODE = 7;  CASCADE_NUX_EVENT_REVERT_STEP = 8;  CASCADE_NUX_EVENT_RULES = 9;  CASCADE_NUX_EVENT_WEB_MENTION = 10;  CASCADE_NUX_EVENT_BACKGROUND_CASCADE = 11;  CASCADE_NUX_EVENT_ANTHROPIC_API_PRICING = 12;  CASCADE_NUX_EVENT_PLAN_MODE = 13;  CASCADE_NUX_EVENT_OPEN_BROWSER_URL = 14;}
-enum ClaudeCodeMode {  CLAUDE_CODE_MODE_UNSPECIFIED = 0;  CLAUDE_CODE_MODE_DEFAULT = 1;  CLAUDE_CODE_MODE_ACCEPT_EDITS = 2;  CLAUDE_CODE_MODE_PLAN = 3;  CLAUDE_CODE_MODE_BYPASS_PERMISSIONS = 4;}
 enum UserNUXEvent {  USER_NUX_EVENT_UNSPECIFIED = 0;  USER_NUX_EVENT_DISMISS_WINDSURF_CROSS_SELL = 1;}
 enum TabToJump {  TAB_TO_JUMP_UNSPECIFIED = 0;  TAB_TO_JUMP_ENABLED = 1;  TAB_TO_JUMP_DISABLED = 2;}
 enum CascadeWebSearchTool {  CASCADE_WEB_SEARCH_TOOL_UNSPECIFIED = 0;  CASCADE_WEB_SEARCH_TOOL_ENABLED = 1;  CASCADE_WEB_SEARCH_TOOL_DISABLED = 2;}
 enum PlanMode {  PLAN_MODE_UNSPECIFIED = 0;  PLAN_MODE_ON = 1;  PLAN_MODE_OFF = 2;}
-enum CascadeRunExtensionCode {  CASCADE_RUN_EXTENSION_CODE_UNSPECIFIED = 0;  CASCADE_RUN_EXTENSION_CODE_ENABLED = 1;  CASCADE_RUN_EXTENSION_CODE_DISABLED = 2;  CASCADE_RUN_EXTENSION_CODE_ONLY = 3;}
 enum AutoContinueOnMaxGeneratorInvocations {  AUTO_CONTINUE_ON_MAX_GENERATOR_INVOCATIONS_UNSPECIFIED = 0;  AUTO_CONTINUE_ON_MAX_GENERATOR_INVOCATIONS_ENABLED = 1;  AUTO_CONTINUE_ON_MAX_GENERATOR_INVOCATIONS_DISABLED = 2;}
 enum AnnotationsConfig {  ANNOTATIONS_CONFIG_UNSPECIFIED = 0;  ANNOTATIONS_CONFIG_ENABLED = 1;  ANNOTATIONS_CONFIG_DISABLED = 2;}
 enum BrowserExperimentalFeaturesConfig {  BROWSER_EXPERIMENTAL_FEATURES_CONFIG_UNSPECIFIED = 0;  BROWSER_EXPERIMENTAL_FEATURES_CONFIG_ENABLED = 1;  BROWSER_EXPERIMENTAL_FEATURES_CONFIG_DISABLED = 2;}
 enum CommandPopupAutocomplete {  COMMAND_POPUP_AUTOCOMPLETE_UNSPECIFIED = 0;  COMMAND_POPUP_AUTOCOMPLETE_ENABLED = 1;  COMMAND_POPUP_AUTOCOMPLETE_DISABLED = 2;}
+enum CompletionMode {  COMPLETION_MODE_UNSPECIFIED = 0;  COMPLETION_MODE_SUPERCOMPLETE = 1;  COMPLETION_MODE_AUTOCOMPLETE = 2;  COMPLETION_MODE_OFF = 3;}
 enum UserTeamStatus {  USER_TEAM_STATUS_UNSPECIFIED = 0;  USER_TEAM_STATUS_PENDING = 1;  USER_TEAM_STATUS_APPROVED = 2;  USER_TEAM_STATUS_REJECTED = 3;}
 enum UserFeatures {  USER_FEATURES_UNSPECIFIED = 0;  USER_FEATURES_CORTEX = 1;  USER_FEATURES_CORTEX_TEST = 2;}
 enum TeamsFeatures {  TEAMS_FEATURES_UNSPECIFIED = 0;  TEAMS_FEATURES_SSO = 1;  TEAMS_FEATURES_ATTRIBUTION = 2;  TEAMS_FEATURES_PHI = 3;  TEAMS_FEATURES_CORTEX = 4;  TEAMS_FEATURES_OPENAI_DISABLED = 5;  TEAMS_FEATURES_REMOTE_INDEXING_DISABLED = 6;  TEAMS_FEATURES_API_KEY_ENABLED = 7;}
 enum Permission {  PERMISSION_UNSPECIFIED = 0;  PERMISSION_ATTRIBUTION_READ = 1;  PERMISSION_ANALYTICS_READ = 2;  PERMISSION_LICENSE_READ = 3;  PERMISSION_TEAM_USER_READ = 4;  PERMISSION_TEAM_USER_UPDATE = 5;  PERMISSION_TEAM_USER_DELETE = 6;  PERMISSION_TEAM_USER_INVITE = 17;  PERMISSION_INDEXING_READ = 7;  PERMISSION_INDEXING_CREATE = 8;  PERMISSION_INDEXING_UPDATE = 9;  PERMISSION_INDEXING_DELETE = 10;  PERMISSION_INDEXING_MANAGEMENT = 27;  PERMISSION_FINETUNING_READ = 19;  PERMISSION_FINETUNING_CREATE = 20;  PERMISSION_FINETUNING_UPDATE = 21;  PERMISSION_FINETUNING_DELETE = 22;  PERMISSION_SSO_READ = 11;  PERMISSION_SSO_WRITE = 12;  PERMISSION_SERVICE_KEY_READ = 13;  PERMISSION_SERVICE_KEY_CREATE = 14;  PERMISSION_SERVICE_KEY_UPDATE = 28;  PERMISSION_SERVICE_KEY_DELETE = 15;  PERMISSION_ROLE_READ = 23;  PERMISSION_ROLE_CREATE = 24;  PERMISSION_ROLE_UPDATE = 25;  PERMISSION_ROLE_DELETE = 26;  PERMISSION_BILLING_READ = 16;  PERMISSION_BILLING_WRITE = 18;  PERMISSION_EXTERNAL_CHAT_UPDATE = 29;  PERMISSION_TEAM_SETTINGS_READ = 30;  PERMISSION_TEAM_SETTINGS_UPDATE = 31;}
 enum TransactionStatus {  TRANSACTION_STATUS_UNSPECIFIED = 0;  TRANSACTION_STATUS_SUCCEEDED = 1;  TRANSACTION_STATUS_PROCESSING = 2;  TRANSACTION_STATUS_FAILED = 3;  TRANSACTION_STATUS_NO_ACTIVE = 4;}
+enum RefreshCustomizationType {  REFRESH_CUSTOMIZATION_TYPE_UNSPECIFIED = 0;  REFRESH_CUSTOMIZATION_TYPE_RULE = 1;  REFRESH_CUSTOMIZATION_TYPE_WORKFLOW = 2;  REFRESH_CUSTOMIZATION_TYPE_USER_MEMORY = 3;  REFRESH_CUSTOMIZATION_TYPE_SKILL = 4;  REFRESH_CUSTOMIZATION_TYPE_PLAN = 5;  REFRESH_CUSTOMIZATION_TYPE_MCP = 6;}
+enum TerminalShellCommandSource {  TERMINAL_SHELL_COMMAND_SOURCE_UNSPECIFIED = 0;  TERMINAL_SHELL_COMMAND_SOURCE_USER = 1;  TERMINAL_SHELL_COMMAND_SOURCE_CASCADE = 2;}
 enum ModelStatus {  MODEL_STATUS_UNSPECIFIED = 0;  MODEL_STATUS_INFO = 1;  MODEL_STATUS_WARNING = 2;}
-enum CascadeNUXLocation {  CASCADE_NUX_LOCATION_UNSPECIFIED = 0;  CASCADE_NUX_LOCATION_CASCADE_INPUT = 1;  CASCADE_NUX_LOCATION_MODEL_SELECTOR = 2;  CASCADE_NUX_LOCATION_RULES_TAB = 4;  CASCADE_NUX_LOCATION_REVERT_STEP = 6;  CASCADE_NUX_LOCATION_PLAN_MODE = 7;  CASCADE_NUX_LOCATION_WRITE_CHAT_MODE = 8;  CASCADE_NUX_LOCATION_TOOLBAR = 9;}
-enum CascadeNUXTrigger {  CASCADE_NUX_TRIGGER_UNSPECIFIED = 0;  CASCADE_NUX_TRIGGER_PRODUCED_CODE_DIFF = 1;  CASCADE_NUX_TRIGGER_OPEN_BROWSER_URL = 3;  CASCADE_NUX_TRIGGER_WEB_SEARCH = 4;}
-enum CascadeNUXIcon {  CASCADE_NUX_ICON_UNSPECIFIED = 0;  CASCADE_NUX_ICON_WEB_SEARCH = 1;  CASCADE_NUX_ICON_WINDSURF_BROWSER = 2;}

--- a/protos/exa.cortex_pb.proto
+++ b/protos/exa.cortex_pb.proto
@@ -28,11 +28,14 @@ message CortexStepMetadata {  uint32 step_generation_version = 21;
   repeated string arguments_order = 5;
   exa.codeium_common_pb.ModelUsageStats model_usage = 9;
   float model_cost = 10;
-  exa.codeium_common_pb.Model generator_model = 11;
-  exa.codeium_common_pb.ModelOrAlias requested_model = 13;
+  exa.codeium_common_pb.Model generator_model_deprecated = 11;
+  exa.codeium_common_pb.ModelOrAlias requested_model_deprecated = 13;
+  string generator_model_uid = 27;
+  string requested_model_uid = 28;
   string execution_id = 12;
   int32 flow_credits_used = 14;
   int32 prompt_credits_used = 15;
+  exa.codeium_common_pb.ConversationalPlannerMode planner_mode = 26;
   repeated exa.cortex_pb.CortexStepCreditReason non_standard_credit_reasons = 18;
   repeated exa.codeium_common_pb.ChatToolCall tool_call_choices = 16;
   string tool_call_choice_reason = 17;
@@ -40,6 +43,12 @@ message CortexStepMetadata {  uint32 step_generation_version = 21;
   int32 tool_call_output_tokens = 23;
   exa.cortex_pb.SourceTrajectoryStepInfo source_trajectory_step_info = 20;
   string request_id = 24;
+  uint64 cumulative_tokens_at_step = 25;
+  double acu_cost = 29;
+}
+
+message WindsurfSetting {  string setting_id = 1;
+  string setting_name = 2;
 }
 
 message StructuredErrorPart {  string text = 1;
@@ -47,6 +56,7 @@ message StructuredErrorPart {  string text = 1;
   string directory_uri = 3;
   string url = 4;
   string code_text = 5;
+  exa.cortex_pb.WindsurfSetting windsurf_setting = 6;
 }
 
 message CortexErrorDetails {  string user_error_message = 1;
@@ -70,15 +80,21 @@ message CascadeTaskResolutionInteractionSpec {  string title = 1;
   string description = 2;
 }
 
-message CascadeClaudeCodeToolPermissionInteractionSpec {  string tool_name = 1;
-  string tool_id = 2;
+message CascadeUpsertCodemapInteractionSpec {}
+
+message CascadeReadUrlContentInteractionSpec {  string url = 1;
+  string origin = 2;
 }
+
+message CascadeAskUserQuestionInteractionSpec {}
 
 message RequestedInteraction {  exa.cortex_pb.CascadeDeployInteractionSpec deploy = 2;
   exa.cortex_pb.CascadeRunCommandInteractionSpec run_command = 3;
   exa.cortex_pb.CascadeRunExtensionCodeInteractionSpec run_extension_code = 5;
   exa.cortex_pb.CascadeTaskResolutionInteractionSpec resolve_task = 11;
-  exa.cortex_pb.CascadeClaudeCodeToolPermissionInteractionSpec claude_code_tool_permission = 12;
+  exa.cortex_pb.CascadeUpsertCodemapInteractionSpec upsert_codemap = 13;
+  exa.cortex_pb.CascadeReadUrlContentInteractionSpec read_url_content = 14;
+  exa.cortex_pb.CascadeAskUserQuestionInteractionSpec ask_user_question = 15;
 }
 
 message UserStepSnapshot {  string name = 1;
@@ -89,6 +105,7 @@ message UserStepAnnotations {  exa.cortex_pb.UserStepSnapshot snapshot = 1;
 
 message CommandHookSpec {  string command = 1;
   string working_directory = 2;
+  bool show_output = 3;
 }
 
 message HookExecutionSpec {  exa.cortex_pb.CommandHookSpec command = 1;
@@ -159,8 +176,6 @@ message ActionSpecCommand {  string instruction = 1;
   exa.cortex_pb.LineRangeTarget line_range = 7;
   exa.cortex_pb.CommandContentTarget content_target = 10;
   repeated exa.codeium_common_pb.CodeContextItem reference_ccis = 5;
-  string classification = 11;
-  exa.cortex_pb.InteractiveCascadeEditImportance importance = 12;
 }
 
 message ActionSpecCreateFile {  string instruction = 1;
@@ -381,6 +396,8 @@ message CortexStepPlannerResponse {  string response = 1;
   repeated exa.codeium_common_pb.KnowledgeBaseItemWithMetadata knowledge_base_items = 2;
   string output_id = 9;
   string thinking_id = 10;
+  bytes gemini_thought_signature = 11;
+  string signature_type = 12;
 }
 
 message CortexStepFileBreakdown {  string absolute_path = 1;
@@ -422,8 +439,12 @@ message CortexStepInspectCluster {  string cluster_id = 1;
 }
 
 message RunCommandOutput {  string full = 1;
+  string ansi_output = 4;
   string truncated = 2;
   uint32 num_lines_above = 3;
+}
+
+message SimpleCommand {  repeated string parts = 1;
 }
 
 message CortexStepRunCommand {  string command_line = 23;
@@ -442,6 +463,9 @@ message CortexStepRunCommand {  string command_line = 23;
   exa.cortex_pb.RunCommandOutput combined_output = 21;
   bool used_ide_terminal = 22;
   string raw_debug_output = 24;
+  string shell_integration_failure_reason = 27;
+  string shell_name = 28;
+  repeated exa.cortex_pb.SimpleCommand parsed_commands = 29;
   string command = 1;
   repeated string args = 3;
   string stdout = 4;
@@ -482,6 +506,7 @@ message CortexStepProposeCode {  exa.cortex_pb.ActionSpec action_spec = 1;
   string code_instruction = 3;
   string markdown_language = 4;
   bool blocking = 5;
+  exa.cortex_pb.AcknowledgementType acknowledgement_type = 6;
 }
 
 message CortexStepFind {  string search_directory = 10;
@@ -547,12 +572,16 @@ message CortexMemoryProjectScope {  string file_path = 1;
   exa.cortex_pb.CortexMemoryTrigger trigger = 4;
   string description = 5;
   repeated string globs = 6;
+  exa.cortex_pb.RuleSource rule_source = 8;
 }
+
+message CortexMemorySystemScope {}
 
 message CortexMemoryScope {  exa.cortex_pb.CortexMemoryGlobalScope global_scope = 1;
   exa.cortex_pb.CortexMemoryLocalScope local_scope = 2;
   exa.cortex_pb.CortexMemoryAllScope all_scope = 3;
   exa.cortex_pb.CortexMemoryProjectScope project_scope = 4;
+  exa.cortex_pb.CortexMemorySystemScope system_scope = 5;
 }
 
 message CortexMemoryText {  string content = 1;
@@ -581,6 +610,8 @@ message CortexStepReadUrlContent {  string url = 1;
   exa.codeium_common_pb.KnowledgeBaseItem web_document = 2;
   string resolved_url = 3;
   uint32 latency_ms = 4;
+  bool user_rejected = 6;
+  exa.cortex_pb.AutoRunDecision auto_run_decision = 7;
 }
 
 message CortexStepViewContentChunk {  string document_id = 5;
@@ -641,15 +672,18 @@ message CascadeConversationalV2PlannerConfig {  exa.codeium_common_pb.Conversati
 }
 
 message CascadeAgenticPlannerManagerConfig {  bool enabled = 1;
-  exa.codeium_common_pb.Model model = 2;
+  exa.codeium_common_pb.Model model_deprecated = 2;
+  string model_uid = 5;
   bool condense_messages = 3;
   bool send_only_user_messages = 4;
 }
 
 message CascadeAgenticPlannerApplierConfig {  bool enabled = 1;
-  exa.codeium_common_pb.Model model = 2;
+  exa.codeium_common_pb.Model model_deprecated = 2;
+  string model_uid = 5;
   int32 num_rollouts = 3;
-  exa.codeium_common_pb.Model judge_model = 4;
+  exa.codeium_common_pb.Model judge_model_deprecated = 4;
+  string judge_model_uid = 6;
 }
 
 message CascadeAgenticPlannerConfig {  bool enable_feedback_loop = 1;
@@ -673,6 +707,11 @@ message CascadeSummarizerConfig {  bool enabled = 1;
 }
 
 message CascadeAgentV2PlannerConfig {  exa.cortex_pb.CascadeSummarizerConfig summarizer_config = 1;
+}
+
+message CascadeCodemapPlannerConfig {}
+
+message CascadeLifeguardPlannerConfig {  string agent_version = 1;
 }
 
 message MqueryToolConfig {  exa.codeium_common_pb.MQueryConfig m_query_config = 1;
@@ -723,14 +762,14 @@ message CodeToolConfig {  repeated string disable_extensions = 1;
   bool only_show_incremental_diff_zone = 11;
   repeated string file_allowlist = 12;
   repeated string dir_allowlist = 17;
-  bool classify_edit = 13;
+  repeated string plan_dirs = 19;
   bool run_proposal_extension_verifier = 14;
   bool skip_await_lint_errors = 15;
-  bool provide_importance = 16;
   bool allow_edit_rules_files = 18;
 }
 
-message IntentToolConfig {  exa.codeium_common_pb.Model intent_model = 1;
+message IntentToolConfig {  exa.codeium_common_pb.Model intent_model_deprecated = 1;
+  string intent_model_uid = 3;
   uint32 max_context_tokens = 2;
 }
 
@@ -759,6 +798,8 @@ message AutoCommandConfig {  bool enable_model_auto_run = 1;
   repeated string system_denylist = 5;
   repeated string system_nooplist = 7;
   exa.codeium_common_pb.CascadeCommandsAutoExecution auto_execution_policy = 6;
+  exa.codeium_common_pb.CascadeCommandsAutoExecution max_auto_execution_level = 8;
+  exa.codeium_common_pb.CascadeCommandsAutoExecution workflow_auto_execution_policy = 9;
 }
 
 message RunCommandToolConfig {  uint32 max_chars_command_stdout = 1;
@@ -770,6 +811,8 @@ message RunCommandToolConfig {  uint32 max_chars_command_stdout = 1;
   string shell_path = 6;
   uint32 max_timeout_ms = 7;
   exa.cortex_pb.EnterpriseToolConfig enterprise_config = 9;
+  bool use_bash_v2 = 10;
+  string shell_integration_failure_reason = 11;
 }
 
 message KnowledgeBaseSearchToolConfig {  uint32 max_tokens_per_knowledge_base_search = 1;
@@ -799,12 +842,22 @@ message SearchWebToolConfig {  bool force_disable = 1;
   exa.codeium_common_pb.ThirdPartyWebSearchConfig third_party_config = 2;
 }
 
+message AutoWebRequestConfig {  repeated string allowlist = 1;
+  exa.codeium_common_pb.CascadeWebRequestsAutoExecution auto_execution_policy = 2;
+}
+
+message ReadUrlContentToolConfig {  bool force_disable = 1;
+  exa.cortex_pb.AutoWebRequestConfig auto_web_request_config = 2;
+}
+
 message MemoryToolConfig {  bool force_disable = 1;
   bool disable_auto_generate_memories = 2;
+  bool disable_write = 3;
 }
 
 message CustomRecipeConfig {  bool force_disable = 1;
-  exa.codeium_common_pb.Model subagent_model = 2;
+  exa.codeium_common_pb.Model subagent_model_deprecated = 2;
+  string subagent_model_uid = 3;
 }
 
 message McpToolConfig {  bool force_disable = 1;
@@ -837,7 +890,6 @@ message FindAllReferencesConfig {  bool enabled = 1;
 
 message RunExtensionCodeConfig {  bool enabled = 1;
   bool only = 2;
-  exa.codeium_common_pb.CascadeRunExtensionCodeAutoRun auto_run = 3;
 }
 
 message AddAnnotationConfig {  bool enabled = 1;
@@ -850,10 +902,29 @@ message TrajectorySearchToolConfig {  bool force_disable = 1;
   uint32 max_scored_chunks = 4;
 }
 
+message GrepV2ToolConfig {  exa.cortex_pb.EnterpriseToolConfig enterprise_config = 1;
+  bool allow_access_gitignore = 2;
+}
+
 message ToolDescriptionOverrideMap {  map<string, exa.cortex_pb.SectionOverrideConfig> descriptions = 1;
 }
 
 message AutoCascadeBroadcastToolConfig {  bool force_disable = 1;
+}
+
+message NotebookToolConfig {  bool enabled = 1;
+}
+
+message FindCodeContextToolConfig {  bool force_disable = 1;
+}
+
+message SmartFriendToolConfig {  string smart_friend_model_uid = 2;
+}
+
+message ExitPlanModeToolConfig {  bool enabled = 1;
+}
+
+message AskUserQuestionToolConfig {  bool enabled = 1;
 }
 
 message CascadeToolConfig {  exa.cortex_pb.MqueryToolConfig mquery = 1;
@@ -868,6 +939,7 @@ message CascadeToolConfig {  exa.cortex_pb.MqueryToolConfig mquery = 1;
   exa.cortex_pb.ViewFileToolConfig view_file = 10;
   exa.cortex_pb.SuggestedResponseConfig suggested_response = 11;
   exa.cortex_pb.SearchWebToolConfig search_web = 13;
+  exa.cortex_pb.ReadUrlContentToolConfig read_url_content = 37;
   exa.cortex_pb.MemoryToolConfig memory = 14;
   exa.cortex_pb.CustomRecipeConfig custom_recipe = 15;
   exa.cortex_pb.McpToolConfig mcp = 16;
@@ -881,9 +953,15 @@ message CascadeToolConfig {  exa.cortex_pb.MqueryToolConfig mquery = 1;
   exa.cortex_pb.RunExtensionCodeConfig run_extension_code = 26;
   exa.cortex_pb.AddAnnotationConfig add_annotation = 27;
   exa.cortex_pb.TrajectorySearchToolConfig trajectory_search = 28;
+  exa.cortex_pb.GrepV2ToolConfig grep_v2 = 33;
   exa.cortex_pb.ToolDescriptionOverrideMap description_override_map = 22;
   bool disable_simple_research_tools = 29;
   exa.cortex_pb.AutoCascadeBroadcastToolConfig auto_cascade_broadcast = 30;
+  exa.cortex_pb.NotebookToolConfig notebook = 31;
+  exa.cortex_pb.FindCodeContextToolConfig find_code_context = 34;
+  exa.cortex_pb.SmartFriendToolConfig smart_friend = 35;
+  exa.cortex_pb.ExitPlanModeToolConfig exit_plan_mode = 38;
+  exa.cortex_pb.AskUserQuestionToolConfig ask_user_question = 39;
   repeated string tool_allowlist = 32;
 }
 
@@ -906,9 +984,13 @@ message CascadePlannerConfig {  exa.cortex_pb.CascadeConversationalPlannerConfig
   exa.cortex_pb.CascadeResearchPlannerConfig research = 10;
   exa.cortex_pb.CascadePassivePlannerConfig passive = 22;
   exa.cortex_pb.CascadeAgentV2PlannerConfig agent_v2 = 24;
+  exa.cortex_pb.CascadeCodemapPlannerConfig codemap = 29;
+  exa.cortex_pb.CascadeLifeguardPlannerConfig lifeguard = 33;
   exa.cortex_pb.CascadeToolConfig tool_config = 13;
-  exa.codeium_common_pb.Model plan_model = 1;
-  exa.codeium_common_pb.ModelOrAlias requested_model = 15;
+  exa.codeium_common_pb.Model plan_model_deprecated = 1;
+  exa.codeium_common_pb.ModelOrAlias requested_model_deprecated = 15;
+  string plan_model_uid = 34;
+  string requested_model_uid = 35;
   uint32 max_iterations = 4;
   uint32 max_step_parse_retries = 5;
   uint32 max_output_tokens = 6;
@@ -922,6 +1004,7 @@ message CascadePlannerConfig {  exa.cortex_pb.CascadeConversationalPlannerConfig
   bool show_all_errors = 25;
   bool is_vibe_and_replace = 28;
   exa.cortex_pb.PromptOverrideConfig prompt_override = 30;
+  repeated string retry_on_response_content = 32;
 }
 
 message CheckpointConfig {  uint32 token_threshold = 1;
@@ -930,12 +1013,11 @@ message CheckpointConfig {  uint32 token_threshold = 1;
   uint32 max_token_limit = 5;
   uint32 max_output_tokens = 11;
   uint32 max_plan_search_steps = 12;
-  exa.codeium_common_pb.Model checkpoint_model = 7;
-  exa.codeium_common_pb.Model checkpoint_model_fallback = 13;
+  exa.codeium_common_pb.Model checkpoint_model_deprecated = 7;
+  string checkpoint_model_uid = 14;
+  exa.codeium_common_pb.Model checkpoint_model_fallback_deprecated = 13;
+  string checkpoint_model_fallback_uid = 15;
   bool enabled = 6;
-  exa.cortex_pb.CheckpointType type = 9;
-  bool condense_input_trajectory = 10;
-  bool use_subagent_checkpointer = 8;
 }
 
 message CascadeExecutorConfig {  bool disable_async = 1;
@@ -946,15 +1028,19 @@ message CascadeExecutorConfig {  bool disable_async = 1;
   int32 hold_for_valid_checkpoint_timeout = 6;
   bool research_only = 7;
   bool use_aggressive_snapshotting = 8;
+  bool enable_background_linting = 9;
+  int32 max_lint_injection_count = 10;
 }
 
 message TrajectoryConversionConfig {  bool use_tool_format = 1;
   bool include_input_step = 2;
   bool group_tools_with_planner_response = 3;
   repeated exa.cortex_pb.CortexStepType disabled_step_types = 4;
+  string tool_call_footer = 5;
 }
 
-message MemoryConfig {  exa.codeium_common_pb.Model memory_model = 1;
+message MemoryConfig {  exa.codeium_common_pb.Model memory_model_deprecated = 1;
+  string memory_model_uid = 8;
   uint32 num_checkpoints_for_context = 5;
   int32 num_memories_to_consider = 3;
   int32 max_global_cascade_memories = 4;
@@ -976,7 +1062,8 @@ message BrainUpdateStrategy {  google.protobuf.Empty executor_forced = 2;
 }
 
 message BrainConfig {  bool enabled = 1;
-  exa.codeium_common_pb.Model brain_model = 2;
+  exa.codeium_common_pb.Model brain_model_deprecated = 2;
+  string brain_model_uid = 14;
   bool use_main_model_as_brain_model = 13;
   bool force_no_explanation = 4;
   exa.cortex_pb.BrainFilterStrategy filter_strategy = 5;
@@ -991,19 +1078,17 @@ message BrainConfig {  bool enabled = 1;
 
 message ParallelRolloutConfig {  int32 num_parallel_rollouts = 1;
   uint32 max_invocations_per_rollout = 2;
-  exa.codeium_common_pb.Model guide_model = 3;
+  exa.codeium_common_pb.Model guide_model_deprecated = 3;
+  string guide_model_uid = 6;
   int32 max_guide_invocations = 4;
   bool force_bad_rollout = 5;
 }
 
-message ToolHookCondition {  repeated exa.cortex_pb.CortexStepType step_types = 1;
+message HookCondition {  repeated exa.cortex_pb.HookAgentAction agent_actions = 1;
 }
 
-message CascadeHook {  exa.cortex_pb.ToolHookCondition pre_tool_use = 1;
-  exa.cortex_pb.ToolHookCondition post_tool_use = 2;
-  bool start = 3;
-  bool stop = 4;
-  exa.cortex_pb.HookExecutionSpec hook_spec = 5;
+message CascadeHook {  exa.cortex_pb.HookExecutionSpec hook_spec = 5;
+  exa.cortex_pb.HookCondition condition = 6;
 }
 
 message CascadeConfig {  exa.cortex_pb.CascadePlannerConfig planner_config = 1;
@@ -1015,101 +1100,6 @@ message CascadeConfig {  exa.cortex_pb.CascadePlannerConfig planner_config = 1;
   bool apply_model_default_override = 6;
   exa.cortex_pb.ParallelRolloutConfig parallel_rollout_config = 8;
   repeated exa.cortex_pb.CascadeHook hooks = 9;
-}
-
-message CortexTrajectoryReference {  string trajectory_id = 1;
-  exa.cortex_pb.CortexTrajectoryType trajectory_type = 3;
-  int32 step_index = 2;
-  exa.cortex_pb.CortexStepType step_type = 4;
-}
-
-message MessagePromptMetadata {  uint32 message_index = 1;
-  uint32 segment_index = 2;
-}
-
-message CacheBreakpointMetadata {  uint32 index = 1;
-  exa.chat_pb.PromptCacheOptions options = 2;
-  string content_checksum = 3;
-}
-
-message CacheRequestOptions {  bool enabled = 1;
-  repeated uint32 cache_breakpoint_indices = 2;
-}
-
-message ChatStartMetadata {  google.protobuf.Timestamp created_at = 4;
-  uint32 start_step_index = 1;
-  int32 checkpoint_index = 2;
-  repeated uint32 steps_covered_by_checkpoint = 3;
-  int32 latest_stable_message_index = 5;
-  repeated exa.cortex_pb.CacheBreakpointMetadata cache_breakpoints = 6;
-  exa.cortex_pb.CacheBreakpointMetadata system_prompt_cache = 7;
-  google.protobuf.Duration time_since_last_invocation = 8;
-  exa.cortex_pb.CacheRequestOptions cache_request = 9;
-}
-
-message ChatModelMetadata {  string system_prompt = 1;
-  repeated exa.chat_pb.ChatMessagePrompt message_prompts = 2;
-  repeated exa.cortex_pb.MessagePromptMetadata message_metadata = 10;
-  exa.codeium_common_pb.Model model = 3;
-  exa.codeium_common_pb.ModelUsageStats usage = 4;
-  float model_cost = 5;
-  uint32 last_cache_index = 6;
-  exa.chat_pb.ChatToolChoice tool_choice = 7;
-  repeated exa.chat_pb.ChatToolDefinition tools = 8;
-  exa.cortex_pb.ChatStartMetadata chat_start_metadata = 9;
-  google.protobuf.Duration time_to_first_token = 11;
-  google.protobuf.Duration streaming_duration = 12;
-  int32 credit_cost = 13;
-  uint32 retries = 14;
-}
-
-message CortexStepTrajectoryChoice {  repeated string proposal_trajectory_ids = 1;
-  int32 choice = 2;
-  string reason = 3;
-}
-
-message ParallelRolloutGeneratorMetadata {  string guide_judgement_trajectory_id = 1;
-  exa.cortex_pb.CortexStepTrajectoryChoice guide_choice_step = 2;
-}
-
-message CortexStepGeneratorMetadata {  repeated uint32 step_indices = 2;
-  exa.cortex_pb.ChatModelMetadata chat_model = 1;
-  exa.cortex_pb.CascadePlannerConfig planner_config = 3;
-  string execution_id = 4;
-  string error = 5;
-  exa.cortex_pb.ParallelRolloutGeneratorMetadata parallel_rollout_generator_metadata = 6;
-}
-
-message ExecutorMetadata {  exa.cortex_pb.ExecutorTerminationReason termination_reason = 1;
-  int32 num_generator_invocations = 2;
-  int32 last_step_idx = 3;
-  bool proceeded_with_auto_continue = 4;
-}
-
-message CortexWorkspaceMetadata {  string workspace_folder_absolute_uri = 1;
-  string git_root_absolute_uri = 2;
-  exa.codeium_common_pb.Repository repository = 3;
-  string branch_name = 4;
-}
-
-message CortexTrajectoryMetadata {  repeated exa.cortex_pb.CortexWorkspaceMetadata workspaces = 1;
-  google.protobuf.Timestamp created_at = 2;
-  string initialization_state_id = 3;
-  string experiment_tags = 4;
-}
-
-message CortexTrajectory {  string trajectory_id = 1;
-  string cascade_id = 6;
-  exa.cortex_pb.CortexTrajectoryType trajectory_type = 4;
-  repeated exa.cortex_pb.CortexTrajectoryStep steps = 2;
-  repeated exa.cortex_pb.CortexTrajectoryReference parent_references = 5;
-  repeated exa.cortex_pb.CortexStepGeneratorMetadata generator_metadata = 3;
-  repeated exa.cortex_pb.ExecutorMetadata executor_metadatas = 9;
-  exa.cortex_pb.CortexTrajectorySource source = 8;
-  exa.cortex_pb.CortexTrajectoryMetadata metadata = 7;
-  string renamed_title = 10;
-  string claude_code_session_id = 11;
-  bool is_claude_code = 12;
 }
 
 message CustomToolSpec {  string recipe_id = 1;
@@ -1146,6 +1136,11 @@ message CortexStepToolCallProposal {  exa.codeium_common_pb.ChatToolCall tool_ca
 
 message CortexStepToolCallChoice {  repeated exa.codeium_common_pb.ChatToolCall proposal_tool_calls = 1;
   uint32 choice = 2;
+  string reason = 3;
+}
+
+message CortexStepTrajectoryChoice {  repeated string proposal_trajectory_ids = 1;
+  int32 choice = 2;
   string reason = 3;
 }
 
@@ -1328,44 +1323,229 @@ message CortexStepTodoList {  repeated exa.cortex_pb.CortexTodoListItem todos = 
 
 message CortexStepBlocking {}
 
-message CortexStepClaudeCodeAgent {  string subagent_type = 1;
-  string description = 2;
-  string prompt = 3;
-  string uri = 4;
+message CortexStepExploreResponse {  string query_id = 1;
+  string response = 2;
 }
 
-message ClaudeCodeTodoListItem {  string id = 1;
+message CortexStepReadNotebook {  string absolute_path_uri = 1;
   string content = 2;
-  string status = 3;
-  string priority = 4;
+  string raw_content = 3;
 }
 
-message CortexStepClaudeCodeTodoList {  repeated exa.cortex_pb.ClaudeCodeTodoListItem todos = 1;
+message CortexStepEditNotebook {  string absolute_path_uri = 1;
+  uint32 cell_number = 2;
+  string cell_id = 6;
+  string new_source = 3;
+  string cell_type = 4;
+  exa.cortex_pb.EditMode edit_mode = 5;
+  string original_content = 7;
+  string new_content = 8;
+  exa.cortex_pb.AcknowledgementType acknowledgement_type = 9;
+  string triggered_memories = 10;
+  repeated exa.codeium_common_pb.CodeDiagnostic lint_errors = 11;
+  repeated exa.codeium_common_pb.CodeDiagnostic persistent_lint_errors = 12;
+  exa.diff_action_pb.UnifiedDiff cell_diff = 13;
 }
 
-message CortexStepClaudeCodeGlob {  string pattern = 1;
-  string output = 2;
+message CortexStepCodeMap {  string code_map_json_content = 1;
 }
 
-message ClaudeCodePermissionDenial {  string tool_name = 1;
-  string tool_use_id = 2;
-  string tool_input = 3;
+message CortexStepEditCodeMap {  string edit_json_content = 1;
 }
 
-message CortexStepClaudeCodeDone {  float usd_spent = 1;
-  repeated exa.cortex_pb.ClaudeCodePermissionDenial permission_denials = 2;
+message CortexStepSupercompleteActiveDoc {  string instruction = 1;
+  exa.codeium_common_pb.FileRangeContent selection_with_cursor = 2;
 }
 
-message CortexStepClaudeCodeResult {  float usd_spent = 1;
-  repeated exa.cortex_pb.ClaudeCodePermissionDenial permission_denials = 2;
+message InstantContextToolCall {  string command_type = 1;
+  string param = 2;
+  exa.cortex_pb.ExecutionStatus execution_status = 3;
+  string error_message = 4;
+  string tool_call_id = 5;
+  float duration_seconds = 6;
 }
 
-message CortexStepClaudeCodeToolPermission {  string tool_name = 1;
-  string tool_id = 2;
-  string tool_description = 3;
-  map<string, string> tool_parameters = 4;
-  bool user_approved = 5;
-  exa.cortex_pb.ClaudeCodeToolPermissionAction action = 6;
+message InstantContextStep {  repeated exa.cortex_pb.InstantContextToolCall tool_calls = 1;
+  string thoughts = 2;
+}
+
+message LineRange {  int32 start = 1;
+  int32 end = 2;
+}
+
+message LineRangeList {  repeated exa.cortex_pb.LineRange ranges = 1;
+}
+
+message CommandTiming {  string label = 1;
+  string command_type = 2;
+  float exec_duration_secs = 3;
+  bool errored = 4;
+}
+
+message TurnTiming {  float model_latency_secs = 1;
+  float tool_call_parse_duration_secs = 2;
+  float command_build_duration_secs = 3;
+  float tool_exec_duration_secs = 4;
+  repeated exa.cortex_pb.CommandTiming commands = 5;
+}
+
+message InstantContextTiming {  float total_duration_secs = 1;
+  float answer_parse_duration_secs = 2;
+  repeated exa.cortex_pb.TurnTiming turns = 3;
+}
+
+message InstantContextResponse {  map<string, exa.cortex_pb.LineRangeList> range_map = 1;
+  float deprecated_duration_field_2 = 2;
+  float duration = 3;
+  map<string, exa.cortex_pb.LineRangeList> raw_range_map = 4;
+  exa.cortex_pb.InstantContextTiming timing = 5;
+}
+
+message CortexStepFindCodeContext {  string search_term = 1;
+  repeated exa.cortex_pb.InstantContextStep steps = 2;
+  exa.cortex_pb.InstantContextResponse response = 3;
+  string workspace_directory_path = 4;
+  string error = 5;
+}
+
+message CortexStepSupercompleteFeedback {  string completion_id = 1;
+  string completion_text = 2;
+  string feedback_type = 3;
+  string feedback_reason = 4;
+  exa.codeium_common_pb.Document document = 5;
+  int64 feedback_delay_ms = 6;
+  exa.codeium_common_pb.ProviderSource provider_source = 7;
+}
+
+message CortexStepLintFixMessage {  repeated exa.codeium_common_pb.CodeDiagnostic lint_errors = 1;
+  repeated exa.codeium_common_pb.CodeDiagnostic persistent_lint_errors = 2;
+}
+
+message CortexStepGrepSearchV2 {  string search_path_uri = 1;
+  string pattern = 2;
+  string path = 3;
+  string glob = 4;
+  string output_mode = 5;
+  int32 lines_after = 6;
+  int32 lines_before = 7;
+  int32 lines_both = 8;
+  bool case_insensitive = 10;
+  string type = 11;
+  int32 head_limit = 12;
+  bool multiline = 13;
+  string command_run = 14;
+  string raw_output = 15;
+  bool no_files_searched = 16;
+  bool timed_out = 17;
+}
+
+message UpsertCodemapOutput {  string id = 1;
+  string title = 2;
+  string codemap_json = 3;
+  string description = 4;
+}
+
+message UpsertCodemapRunningStatus {  int32 step = 1;
+  string step_status = 2;
+}
+
+message CortexStepUpsertCodemap {  string prompt = 1;
+  repeated string starting_points = 2;
+  bool blocking = 3;
+  string editing_codemap_id = 4;
+  string editing_codemap_title = 5;
+  bool user_rejected = 6;
+  exa.cortex_pb.UpsertCodemapOutput output = 7;
+  exa.cortex_pb.UpsertCodemapRunningStatus running_status = 8;
+}
+
+message CodeMapSuggestion {  string id = 1;
+  string prompt = 2;
+  repeated string starting_points = 3;
+  bool dismissed = 4;
+  string subtitle = 5;
+}
+
+message CortexStepSuggestCodemap {  repeated exa.cortex_pb.CodeMapSuggestion suggestions = 1;
+}
+
+message CortexStepSmartFriend {  string question = 1;
+  string advice = 2;
+  exa.codeium_common_pb.Model model_deprecated = 3;
+  string model_uid = 6;
+  string model_name = 4;
+  string smart_friend_request_id = 5;
+}
+
+message LifeguardBug {  string id = 1;
+  string file = 2;
+  int32 start = 3;
+  int32 end = 4;
+  string title = 5;
+  string description = 6;
+  string severity = 7;
+  string resolution = 8;
+  string fix_old_str = 9;
+  string fix_new_str = 10;
+}
+
+message CortexStepReportBugs {  repeated exa.cortex_pb.LifeguardBug bugs = 1;
+}
+
+message CortexStepExitPlanMode {  string plan_file = 1;
+  bool user_requested = 2;
+}
+
+message AskUserQuestionOption {  string label = 1;
+  string description = 2;
+}
+
+message Request {  string question = 1;
+  repeated exa.cortex_pb.AskUserQuestionOption options = 2;
+  bool allow_multiple = 3;
+}
+
+message SelectedOptions {  repeated int32 indices = 1;
+}
+
+message Response {  exa.cortex_pb.SelectedOptions selected_options = 1;
+  exa.cortex_pb.CortexStepUserInput user_input = 2;
+}
+
+message CortexStepAskUserQuestion {  exa.cortex_pb.Request request = 1;
+  exa.cortex_pb.Response response = 2;
+}
+
+message CortexStepSkill {  string skill_name = 1;
+  string description = 2;
+  string path = 3;
+  int32 resource_count = 4;
+  string base_dir = 5;
+  string content = 6;
+}
+
+message SupercompleteTabJumpInfo {  string path = 1;
+  exa.codeium_common_pb.DocumentPosition jump_position = 2;
+  bool is_import = 3;
+}
+
+message SupercompleteEphemeralFeedbackEntry {  bool accepted = 1;
+  bool intentional_reject = 2;
+  string completion_id = 3;
+  int64 timestamp_ms = 4;
+  exa.diff_action_pb.UnifiedDiff unified_diff = 5;
+  uint64 selection_start_line = 7;
+  exa.cortex_pb.SupercompleteTabJumpInfo tabjump_suggestion = 6;
+}
+
+message CortexStepSupercompleteEphemeralFeedback {  repeated exa.cortex_pb.SupercompleteEphemeralFeedbackEntry feedback_entries = 1;
+  int64 creation_timestamp_ms = 2;
+}
+
+message CortexStepArenaTrajectoryConverge {  string source_model_uid = 1;
+  string source_cascade_id = 2;
+  repeated exa.cortex_pb.CortexTrajectoryStep original_steps = 3;
+  string destination_model_uid = 4;
 }
 
 message CortexTrajectoryStep {  exa.cortex_pb.CortexStepType type = 1;
@@ -1377,6 +1557,7 @@ message CortexTrajectoryStep {  exa.cortex_pb.CortexStepType type = 1;
   exa.cortex_pb.UserStepAnnotations user_annotations = 69;
   repeated exa.cortex_pb.HookExecutionDetail pre_tool_use_hooks = 85;
   repeated exa.cortex_pb.HookExecutionDetail post_tool_use_hooks = 86;
+  bool shield_from_cancellation = 109;
   exa.cortex_pb.CortexStepDummy dummy = 7;
   exa.cortex_pb.CortexStepFinish finish = 12;
   exa.cortex_pb.CortexStepPlanInput plan_input = 8;
@@ -1441,14 +1622,160 @@ message CortexTrajectoryStep {  exa.cortex_pb.CortexStepType type = 1;
   exa.cortex_pb.CortexStepResolveTask resolve_task = 84;
   exa.cortex_pb.CortexStepTodoList todo_list = 87;
   exa.cortex_pb.CortexStepBlocking blocking = 88;
-  exa.cortex_pb.CortexStepClaudeCodeAgent claude_code_agent = 89;
-  exa.cortex_pb.CortexStepClaudeCodeTodoList claude_code_todo_list = 90;
-  exa.cortex_pb.CortexStepClaudeCodeGlob claude_code_glob = 91;
-  exa.cortex_pb.CortexStepClaudeCodeDone claude_code_done = 92;
-  exa.cortex_pb.CortexStepClaudeCodeResult claude_code_result = 93;
-  exa.cortex_pb.CortexStepClaudeCodeToolPermission claude_code_tool_permission = 95;
+  exa.cortex_pb.CortexStepExploreResponse explore_response = 94;
+  exa.cortex_pb.CortexStepReadNotebook read_notebook = 96;
+  exa.cortex_pb.CortexStepEditNotebook edit_notebook = 97;
+  exa.cortex_pb.CortexStepCodeMap code_map = 98;
+  exa.cortex_pb.CortexStepEditCodeMap edit_code_map = 99;
+  exa.cortex_pb.CortexStepSupercompleteActiveDoc supercomplete_active_doc = 100;
+  exa.cortex_pb.CortexStepFindCodeContext find_code_context = 101;
+  exa.cortex_pb.CortexStepSupercompleteFeedback supercomplete_feedback = 103;
+  exa.cortex_pb.CortexStepLintFixMessage lint_fix_message = 104;
+  exa.cortex_pb.CortexStepGrepSearchV2 grep_search_v2 = 105;
+  exa.cortex_pb.CortexStepUpsertCodemap upsert_codemap = 106;
+  exa.cortex_pb.CortexStepSuggestCodemap suggest_codemap = 107;
+  exa.cortex_pb.CortexStepSmartFriend smart_friend = 108;
+  exa.cortex_pb.CortexStepReportBugs report_bugs = 112;
+  exa.cortex_pb.CortexStepExitPlanMode exit_plan_mode = 114;
+  exa.cortex_pb.CortexStepAskUserQuestion ask_user_question = 115;
+  exa.cortex_pb.CortexStepSkill skill = 116;
+  exa.cortex_pb.CortexStepSupercompleteEphemeralFeedback supercomplete_ephemeral_feedback = 117;
+  exa.cortex_pb.CortexStepArenaTrajectoryConverge arena_trajectory_converge = 118;
   exa.cortex_pb.CortexTrajectory subtrajectory = 6;
   repeated exa.cortex_pb.CortexTrajectory subtrajectories = 51;
+}
+
+message CortexTrajectoryReference {  string trajectory_id = 1;
+  exa.cortex_pb.CortexTrajectoryType trajectory_type = 3;
+  int32 step_index = 2;
+  exa.cortex_pb.CortexStepType step_type = 4;
+  bool force_billable = 5;
+}
+
+message MessagePromptMetadata {  uint32 message_index = 1;
+  uint32 segment_index = 2;
+}
+
+message CacheBreakpointMetadata {  uint32 index = 1;
+  exa.chat_pb.PromptCacheOptions options = 2;
+  string content_checksum = 3;
+}
+
+message CacheRequestOptions {  bool enabled = 1;
+  repeated uint32 cache_breakpoint_indices = 2;
+}
+
+message ChatStartMetadata {  google.protobuf.Timestamp created_at = 4;
+  uint32 start_step_index = 1;
+  int32 checkpoint_index = 2;
+  repeated uint32 steps_covered_by_checkpoint = 3;
+  int32 latest_stable_message_index = 5;
+  repeated exa.cortex_pb.CacheBreakpointMetadata cache_breakpoints = 6;
+  exa.cortex_pb.CacheBreakpointMetadata system_prompt_cache = 7;
+  google.protobuf.Duration time_since_last_invocation = 8;
+  exa.cortex_pb.CacheRequestOptions cache_request = 9;
+}
+
+message ChatModelMetadata {  string system_prompt = 1;
+  repeated exa.chat_pb.ChatMessagePrompt message_prompts = 2;
+  repeated exa.cortex_pb.MessagePromptMetadata message_metadata = 10;
+  exa.codeium_common_pb.Model model_deprecated = 3;
+  string model_uid = 15;
+  exa.codeium_common_pb.ModelUsageStats usage = 4;
+  float model_cost = 5;
+  uint32 last_cache_index = 6;
+  exa.chat_pb.ChatToolChoice tool_choice = 7;
+  repeated exa.chat_pb.ChatToolDefinition tools = 8;
+  exa.cortex_pb.ChatStartMetadata chat_start_metadata = 9;
+  google.protobuf.Duration time_to_first_token = 11;
+  google.protobuf.Duration streaming_duration = 12;
+  int32 credit_cost = 13;
+  uint32 retries = 14;
+  double acu_cost = 16;
+}
+
+message ParallelRolloutGeneratorMetadata {  string guide_judgement_trajectory_id = 1;
+  exa.cortex_pb.CortexStepTrajectoryChoice guide_choice_step = 2;
+}
+
+message CortexStepGeneratorMetadata {  repeated uint32 step_indices = 2;
+  exa.cortex_pb.ChatModelMetadata chat_model = 1;
+  exa.cortex_pb.CascadePlannerConfig planner_config = 3;
+  string execution_id = 4;
+  string error = 5;
+  exa.cortex_pb.ParallelRolloutGeneratorMetadata parallel_rollout_generator_metadata = 6;
+  bool arena_cap_reached = 7;
+}
+
+message ExecutorMetadata {  exa.cortex_pb.ExecutorTerminationReason termination_reason = 1;
+  int32 num_generator_invocations = 2;
+  int32 last_step_idx = 3;
+  bool proceeded_with_auto_continue = 4;
+}
+
+message CortexWorkspaceMetadata {  string workspace_folder_absolute_uri = 1;
+  string git_root_absolute_uri = 2;
+  exa.codeium_common_pb.Repository repository = 3;
+  string branch_name = 4;
+}
+
+message CortexTrajectoryMetadata {  repeated exa.cortex_pb.CortexWorkspaceMetadata workspaces = 1;
+  google.protobuf.Timestamp created_at = 2;
+  string initialization_state_id = 3;
+  string experiment_tags = 4;
+}
+
+message QueuedMessage {  string queue_id = 1;
+  exa.codeium_common_pb.Metadata metadata = 2;
+  exa.cortex_pb.CortexTrajectoryStep user_input_step = 3;
+  exa.cortex_pb.CascadeConfig override_config = 4;
+}
+
+message ArenaModeInfo {  bool is_random_mode = 1;
+  exa.codeium_common_pb.ArenaTier arena_tier = 2;
+}
+
+message CortexTrajectory {  string trajectory_id = 1;
+  string cascade_id = 6;
+  exa.cortex_pb.CortexTrajectoryType trajectory_type = 4;
+  repeated exa.cortex_pb.CortexTrajectoryStep steps = 2;
+  repeated exa.cortex_pb.CortexTrajectoryReference parent_references = 5;
+  repeated exa.cortex_pb.CortexStepGeneratorMetadata generator_metadata = 3;
+  repeated exa.cortex_pb.ExecutorMetadata executor_metadatas = 9;
+  exa.cortex_pb.CortexTrajectorySource source = 8;
+  exa.cortex_pb.CortexTrajectoryMetadata metadata = 7;
+  string renamed_title = 10;
+  bytes virtual_fs_serialized_overlay = 13;
+  uint32 diff_lines_added = 14;
+  uint32 diff_lines_removed = 15;
+  string arena_id = 16;
+  repeated exa.cortex_pb.QueuedMessage message_queue = 17;
+  string git_worktree_path = 18;
+  exa.cortex_pb.ArenaModeInfo arena_mode_info = 20;
+  exa.codeium_common_pb.ConversationalPlannerMode conversational_mode = 21;
+}
+
+message TrajectoryScope {  string workspace_uri = 1;
+  string git_root_uri = 2;
+  string branch_name = 3;
+}
+
+message ImplicitTrajectory {  exa.cortex_pb.CortexTrajectory trajectory = 1;
+  exa.cortex_pb.TrajectoryScope trajectory_scope = 5;
+}
+
+message ImplicitTrajectoryDescription {  string trajectory_id = 1;
+  exa.cortex_pb.TrajectoryScope trajectory_scope = 2;
+  bool current = 3;
+}
+
+message BaseTrajectoryIdentifier {  string cascade_id = 1;
+  string implicit_trajectory_file_uri = 2;
+  bool last_active_doc = 3;
+  exa.cortex_pb.CortexTrajectory trajectory = 4;
+}
+
+message RevertMetadata {  repeated string reverted_uris = 4;
 }
 
 message CortexTrajectoryStepWithIndex {  exa.cortex_pb.CortexTrajectoryStep step = 1;
@@ -1482,47 +1809,18 @@ message CascadeTrajectorySummary {  string summary = 1;
   repeated exa.cortex_pb.GlobalBackgroundCommand background_commands = 12;
   exa.cortex_pb.LastTodoListStepInfo last_todo_list_step = 13;
   bool errored = 14;
-  bool is_claude_code = 15;
-}
-
-message CascadeTrajectorySummaries {  map<string, exa.cortex_pb.CascadeTrajectorySummary> summaries = 1;
-}
-
-message TrajectoryScope {  string workspace_uri = 1;
-  string git_root_uri = 2;
-  string branch_name = 3;
-}
-
-message ImplicitTrajectory {  exa.cortex_pb.CortexTrajectory trajectory = 1;
-  exa.cortex_pb.TrajectoryScope trajectory_scope = 5;
-}
-
-message ImplicitTrajectoryDescription {  string trajectory_id = 1;
-  exa.cortex_pb.TrajectoryScope trajectory_scope = 2;
-  bool current = 3;
-}
-
-message BaseTrajectoryIdentifier {  string cascade_id = 1;
-  string implicit_trajectory_file_uri = 2;
-  bool last_active_doc = 3;
-  exa.cortex_pb.CortexTrajectory trajectory = 4;
-}
-
-message RevertOperation {  repeated exa.cortex_pb.CortexTrajectoryStep removed_steps = 1;
-  int32 revert_from_index = 2;
-  int32 revert_to_index = 3;
-}
-
-message RevertState {  exa.cortex_pb.RevertOperation revert_operation = 1;
-  int32 current_position = 2;
-}
-
-message RevertMetadata {  repeated string reverted_uris = 4;
-  exa.cortex_pb.RevertState revert_state = 5;
-}
-
-message UnrevertMetadata {  repeated string unreverted_uris = 1;
-  exa.cortex_pb.RevertState revert_state = 2;
+  uint32 diff_lines_added = 16;
+  uint32 diff_lines_removed = 17;
+  string arena_id = 18;
+  bool hidden = 19;
+  uint32 queue_size = 20;
+  string git_worktree_path = 21;
+  exa.cortex_pb.CortexTrajectoryType trajectory_type = 22;
+  exa.cortex_pb.CortexTrajectorySource trajectory_source = 23;
+  exa.codeium_common_pb.Model last_generator_model_deprecated = 24;
+  exa.cortex_pb.ArenaModeInfo arena_mode_info = 25;
+  string last_generator_model_uid = 26;
+  repeated exa.codeium_common_pb.ContextScopeItem referenced_context_items = 27;
 }
 
 message CascadeDeployInteraction {  bool cancel = 1;
@@ -1543,8 +1841,15 @@ message CascadeTaskResolutionInteraction {  bool confirm = 1;
   exa.cortex_pb.TaskResolution resolution = 2;
 }
 
-message CascadeClaudeCodeToolPermissionInteraction {  exa.cortex_pb.ClaudeCodeToolPermissionAction action = 1;
-  exa.cortex_pb.CascadeClaudeCodeToolPermissionInteractionSpec spec = 2;
+message CascadeUpsertCodemapInteraction {  bool confirm = 1;
+}
+
+message CascadeReadUrlContentInteraction {  exa.cortex_pb.ReadUrlContentAction action = 1;
+  string url = 2;
+  string origin = 3;
+}
+
+message CascadeAskUserQuestionInteraction {  exa.cortex_pb.Response response = 1;
 }
 
 message CascadeUserInteraction {  string trajectory_id = 1;
@@ -1553,7 +1858,13 @@ message CascadeUserInteraction {  string trajectory_id = 1;
   exa.cortex_pb.CascadeRunCommandInteraction run_command = 5;
   exa.cortex_pb.CascadeRunExtensionCodeInteraction run_extension_code = 7;
   exa.cortex_pb.CascadeTaskResolutionInteraction resolve_task = 12;
-  exa.cortex_pb.CascadeClaudeCodeToolPermissionInteraction claude_code_tool_permission = 13;
+  exa.cortex_pb.CascadeUpsertCodemapInteraction upsert_codemap = 14;
+  exa.cortex_pb.CascadeReadUrlContentInteraction read_url_content = 15;
+  exa.cortex_pb.CascadeAskUserQuestionInteraction ask_user_question = 16;
+}
+
+message McpOAuthConfig {  string client_id = 1;
+  repeated string scopes = 2;
 }
 
 message McpServerSpec {  string server_name = 1;
@@ -1565,6 +1876,17 @@ message McpServerSpec {  string server_name = 1;
   bool disabled = 7;
   repeated string disabled_tools = 8;
   map<string, string> headers = 9;
+  exa.cortex_pb.McpOAuthConfig oauth = 10;
+}
+
+message McpPromptArgument {  string name = 1;
+  string description = 2;
+  bool required = 3;
+}
+
+message McpPrompt {  string name = 1;
+  string description = 2;
+  repeated exa.cortex_pb.McpPromptArgument arguments = 3;
 }
 
 message McpServerState {  exa.cortex_pb.McpServerSpec spec = 1;
@@ -1574,6 +1896,7 @@ message McpServerState {  exa.cortex_pb.McpServerSpec spec = 1;
   repeated string tool_errors = 7;
   exa.cortex_pb.McpServerInfo server_info = 5;
   string instructions = 6;
+  repeated exa.cortex_pb.McpPrompt prompts = 8;
 }
 
 message WorkflowSpec {  string path = 1;
@@ -1584,22 +1907,31 @@ message WorkflowSpec {  string path = 1;
   bool is_builtin = 6;
   exa.cortex_pb.CortexMemoryScope scope = 7;
   string base_dir = 8;
+  bool is_overridden = 10;
 }
 
-enum CortexStepType {  CORTEX_STEP_TYPE_UNSPECIFIED = 0;  CORTEX_STEP_TYPE_DUMMY = 1;  CORTEX_STEP_TYPE_FINISH = 2;  CORTEX_STEP_TYPE_PLAN_INPUT = 3;  CORTEX_STEP_TYPE_MQUERY = 4;  CORTEX_STEP_TYPE_CODE_ACTION = 5;  CORTEX_STEP_TYPE_GIT_COMMIT = 6;  CORTEX_STEP_TYPE_GREP_SEARCH = 7;  CORTEX_STEP_TYPE_VIEW_FILE = 8;  CORTEX_STEP_TYPE_LIST_DIRECTORY = 9;  CORTEX_STEP_TYPE_COMPILE = 10;  CORTEX_STEP_TYPE_INFORM = 11;  CORTEX_STEP_TYPE_FILE_BREAKDOWN = 12;  CORTEX_STEP_TYPE_VIEW_CODE_ITEM = 13;  CORTEX_STEP_TYPE_USER_INPUT = 14;  CORTEX_STEP_TYPE_PLANNER_RESPONSE = 15;  CORTEX_STEP_TYPE_WRITE_TO_FILE = 16;  CORTEX_STEP_TYPE_ERROR_MESSAGE = 17;  CORTEX_STEP_TYPE_CLUSTER_QUERY = 18;  CORTEX_STEP_TYPE_LIST_CLUSTERS = 19;  CORTEX_STEP_TYPE_INSPECT_CLUSTER = 20;  CORTEX_STEP_TYPE_RUN_COMMAND = 21;  CORTEX_STEP_TYPE_RELATED_FILES = 22;  CORTEX_STEP_TYPE_CHECKPOINT = 23;  CORTEX_STEP_TYPE_PROPOSE_CODE = 24;  CORTEX_STEP_TYPE_FIND = 25;  CORTEX_STEP_TYPE_SEARCH_KNOWLEDGE_BASE = 26;  CORTEX_STEP_TYPE_SUGGESTED_RESPONSES = 27;  CORTEX_STEP_TYPE_COMMAND_STATUS = 28;  CORTEX_STEP_TYPE_MEMORY = 29;  CORTEX_STEP_TYPE_LOOKUP_KNOWLEDGE_BASE = 30;  CORTEX_STEP_TYPE_READ_URL_CONTENT = 31;  CORTEX_STEP_TYPE_VIEW_CONTENT_CHUNK = 32;  CORTEX_STEP_TYPE_SEARCH_WEB = 33;  CORTEX_STEP_TYPE_RETRIEVE_MEMORY = 34;  CORTEX_STEP_TYPE_AUTO_CASCADE_BROADCAST = 35;  CORTEX_STEP_TYPE_CUSTOM_TOOL = 36;  CORTEX_STEP_TYPE_CREATE_RECIPE = 37;  CORTEX_STEP_TYPE_MCP_TOOL = 38;  CORTEX_STEP_TYPE_MANAGER_FEEDBACK = 39;  CORTEX_STEP_TYPE_TOOL_CALL_PROPOSAL = 40;  CORTEX_STEP_TYPE_TOOL_CALL_CHOICE = 41;  CORTEX_STEP_TYPE_TRAJECTORY_CHOICE = 42;  CORTEX_STEP_TYPE_PROXY_WEB_SERVER = 43;  CORTEX_STEP_TYPE_DEPLOY_WEB_APP = 44;  CORTEX_STEP_TYPE_CLIPBOARD = 45;  CORTEX_STEP_TYPE_READ_DEPLOYMENT_CONFIG = 46;  CORTEX_STEP_TYPE_VIEW_FILE_OUTLINE = 47;  CORTEX_STEP_TYPE_CHECK_DEPLOY_STATUS = 48;  CORTEX_STEP_TYPE_POST_PR_REVIEW = 49;  CORTEX_STEP_TYPE_READ_KNOWLEDGE_BASE_ITEM = 50;  CORTEX_STEP_TYPE_LIST_RESOURCES = 51;  CORTEX_STEP_TYPE_READ_RESOURCE = 52;  CORTEX_STEP_TYPE_LINT_DIFF = 53;  CORTEX_STEP_TYPE_FIND_ALL_REFERENCES = 54;  CORTEX_STEP_TYPE_BRAIN_UPDATE = 55;  CORTEX_STEP_TYPE_RUN_EXTENSION_CODE = 57;  CORTEX_STEP_TYPE_ADD_ANNOTATION = 58;  CORTEX_STEP_TYPE_PROPOSAL_FEEDBACK = 59;  CORTEX_STEP_TYPE_TRAJECTORY_SEARCH = 60;  CORTEX_STEP_TYPE_READ_TERMINAL = 65;  CORTEX_STEP_TYPE_GET_DOM_TREE = 68;  CORTEX_STEP_TYPE_ARTIFACT_SUMMARY = 71;  CORTEX_STEP_TYPE_RESOLVE_TASK = 72;  CORTEX_STEP_TYPE_TODO_LIST = 73;  CORTEX_STEP_TYPE_BLOCKING = 74;  CORTEX_STEP_TYPE_CLAUDE_CODE_AGENT = 75;  CORTEX_STEP_TYPE_CLAUDE_CODE_TODO_LIST = 76;  CORTEX_STEP_TYPE_CLAUDE_CODE_GLOB = 77;  CORTEX_STEP_TYPE_CLAUDE_CODE_DONE = 78;  CORTEX_STEP_TYPE_CLAUDE_CODE_RESULT = 79;  CORTEX_STEP_TYPE_CLAUDE_CODE_TOOL_PERMISSION = 81;}
+message CortexSkill {  string name = 1;
+  string description = 2;
+  string path = 3;
+  int32 resource_count = 4;
+  string base_dir = 5;
+  string content = 6;
+  bool is_global = 7;
+}
+
+enum CortexTrajectoryType {  CORTEX_TRAJECTORY_TYPE_UNSPECIFIED = 0;  CORTEX_TRAJECTORY_TYPE_USER_MAINLINE = 1;  CORTEX_TRAJECTORY_TYPE_USER_GRANULAR = 2;  CORTEX_TRAJECTORY_TYPE_SUPERCOMPLETE = 3;  CORTEX_TRAJECTORY_TYPE_CASCADE = 4;  CORTEX_TRAJECTORY_TYPE_BACKGROUND_RESEARCH = 5;  CORTEX_TRAJECTORY_TYPE_CHECKPOINT = 6;  CORTEX_TRAJECTORY_TYPE_RETRIEVE_MEMORY = 7;  CORTEX_TRAJECTORY_TYPE_CUSTOM_TOOL = 8;  CORTEX_TRAJECTORY_TYPE_AUTO_CASCADE = 9;  CORTEX_TRAJECTORY_TYPE_AUTO_CASCADE_MANAGER = 10;  CORTEX_TRAJECTORY_TYPE_APPLIER = 11;  CORTEX_TRAJECTORY_TYPE_TOOL_CALL_PROPOSAL = 12;  CORTEX_TRAJECTORY_TYPE_TRAJECTORY_CHOICE = 13;  CORTEX_TRAJECTORY_TYPE_LLM_JUDGE = 14;  CORTEX_TRAJECTORY_TYPE_ARTIFACT_SUMMARY = 19;  CORTEX_TRAJECTORY_TYPE_PASSIVE_CODER = 15;  CORTEX_TRAJECTORY_TYPE_INTERACTIVE_CASCADE = 17;  CORTEX_TRAJECTORY_TYPE_BRAIN_UPDATE = 16;}
+enum CortexStepType {  CORTEX_STEP_TYPE_UNSPECIFIED = 0;  CORTEX_STEP_TYPE_DUMMY = 1;  CORTEX_STEP_TYPE_FINISH = 2;  CORTEX_STEP_TYPE_PLAN_INPUT = 3;  CORTEX_STEP_TYPE_MQUERY = 4;  CORTEX_STEP_TYPE_CODE_ACTION = 5;  CORTEX_STEP_TYPE_GIT_COMMIT = 6;  CORTEX_STEP_TYPE_GREP_SEARCH = 7;  CORTEX_STEP_TYPE_VIEW_FILE = 8;  CORTEX_STEP_TYPE_LIST_DIRECTORY = 9;  CORTEX_STEP_TYPE_COMPILE = 10;  CORTEX_STEP_TYPE_INFORM = 11;  CORTEX_STEP_TYPE_FILE_BREAKDOWN = 12;  CORTEX_STEP_TYPE_VIEW_CODE_ITEM = 13;  CORTEX_STEP_TYPE_USER_INPUT = 14;  CORTEX_STEP_TYPE_PLANNER_RESPONSE = 15;  CORTEX_STEP_TYPE_WRITE_TO_FILE = 16;  CORTEX_STEP_TYPE_ERROR_MESSAGE = 17;  CORTEX_STEP_TYPE_CLUSTER_QUERY = 18;  CORTEX_STEP_TYPE_LIST_CLUSTERS = 19;  CORTEX_STEP_TYPE_INSPECT_CLUSTER = 20;  CORTEX_STEP_TYPE_RUN_COMMAND = 21;  CORTEX_STEP_TYPE_RELATED_FILES = 22;  CORTEX_STEP_TYPE_CHECKPOINT = 23;  CORTEX_STEP_TYPE_PROPOSE_CODE = 24;  CORTEX_STEP_TYPE_FIND = 25;  CORTEX_STEP_TYPE_SEARCH_KNOWLEDGE_BASE = 26;  CORTEX_STEP_TYPE_SUGGESTED_RESPONSES = 27;  CORTEX_STEP_TYPE_COMMAND_STATUS = 28;  CORTEX_STEP_TYPE_MEMORY = 29;  CORTEX_STEP_TYPE_LOOKUP_KNOWLEDGE_BASE = 30;  CORTEX_STEP_TYPE_READ_URL_CONTENT = 31;  CORTEX_STEP_TYPE_VIEW_CONTENT_CHUNK = 32;  CORTEX_STEP_TYPE_SEARCH_WEB = 33;  CORTEX_STEP_TYPE_RETRIEVE_MEMORY = 34;  CORTEX_STEP_TYPE_AUTO_CASCADE_BROADCAST = 35;  CORTEX_STEP_TYPE_CUSTOM_TOOL = 36;  CORTEX_STEP_TYPE_CREATE_RECIPE = 37;  CORTEX_STEP_TYPE_MCP_TOOL = 38;  CORTEX_STEP_TYPE_MANAGER_FEEDBACK = 39;  CORTEX_STEP_TYPE_TOOL_CALL_PROPOSAL = 40;  CORTEX_STEP_TYPE_TOOL_CALL_CHOICE = 41;  CORTEX_STEP_TYPE_TRAJECTORY_CHOICE = 42;  CORTEX_STEP_TYPE_PROXY_WEB_SERVER = 43;  CORTEX_STEP_TYPE_DEPLOY_WEB_APP = 44;  CORTEX_STEP_TYPE_CLIPBOARD = 45;  CORTEX_STEP_TYPE_READ_DEPLOYMENT_CONFIG = 46;  CORTEX_STEP_TYPE_VIEW_FILE_OUTLINE = 47;  CORTEX_STEP_TYPE_CHECK_DEPLOY_STATUS = 48;  CORTEX_STEP_TYPE_POST_PR_REVIEW = 49;  CORTEX_STEP_TYPE_READ_KNOWLEDGE_BASE_ITEM = 50;  CORTEX_STEP_TYPE_LIST_RESOURCES = 51;  CORTEX_STEP_TYPE_READ_RESOURCE = 52;  CORTEX_STEP_TYPE_LINT_DIFF = 53;  CORTEX_STEP_TYPE_FIND_ALL_REFERENCES = 54;  CORTEX_STEP_TYPE_BRAIN_UPDATE = 55;  CORTEX_STEP_TYPE_RUN_EXTENSION_CODE = 57;  CORTEX_STEP_TYPE_ADD_ANNOTATION = 58;  CORTEX_STEP_TYPE_PROPOSAL_FEEDBACK = 59;  CORTEX_STEP_TYPE_TRAJECTORY_SEARCH = 60;  CORTEX_STEP_TYPE_READ_TERMINAL = 65;  CORTEX_STEP_TYPE_GET_DOM_TREE = 68;  CORTEX_STEP_TYPE_ARTIFACT_SUMMARY = 71;  CORTEX_STEP_TYPE_RESOLVE_TASK = 72;  CORTEX_STEP_TYPE_TODO_LIST = 73;  CORTEX_STEP_TYPE_BLOCKING = 74;  CORTEX_STEP_TYPE_EXPLORE_RESPONSE = 80;  CORTEX_STEP_TYPE_READ_NOTEBOOK = 82;  CORTEX_STEP_TYPE_EDIT_NOTEBOOK = 83;  CORTEX_STEP_TYPE_SUPERCOMPLETE_ACTIVE_DOC = 86;  CORTEX_STEP_TYPE_FIND_CODE_CONTEXT = 87;  CORTEX_STEP_TYPE_SUPERCOMPLETE_FEEDBACK = 89;  CORTEX_STEP_TYPE_LINT_FIX_MESSAGE = 90;  CORTEX_STEP_TYPE_GREP_SEARCH_V2 = 91;  CORTEX_STEP_TYPE_UPSERT_CODEMAP = 92;  CORTEX_STEP_TYPE_SUGGEST_CODEMAP = 93;  CORTEX_STEP_TYPE_SMART_FRIEND = 94;  CORTEX_STEP_TYPE_DO_TESTING = 95;  CORTEX_STEP_TYPE_REPORT_BUGS = 97;  CORTEX_STEP_TYPE_EXIT_PLAN_MODE = 99;  CORTEX_STEP_TYPE_ASK_USER_QUESTION = 100;  CORTEX_STEP_TYPE_SKILL = 101;  CORTEX_STEP_TYPE_SUPERCOMPLETE_EPHEMERAL_FEEDBACK = 102;  CORTEX_STEP_TYPE_ARENA_TRAJECTORY_CONVERGE = 103;}
 enum CortexStepStatus {  CORTEX_STEP_STATUS_UNSPECIFIED = 0;  CORTEX_STEP_STATUS_GENERATING = 8;  CORTEX_STEP_STATUS_HALTED = 10;  CORTEX_STEP_STATUS_PENDING = 1;  CORTEX_STEP_STATUS_RUNNING = 2;  CORTEX_STEP_STATUS_WAITING = 9;  CORTEX_STEP_STATUS_DONE = 3;  CORTEX_STEP_STATUS_INVALID = 4;  CORTEX_STEP_STATUS_CLEARED = 5;  CORTEX_STEP_STATUS_CANCELED = 6;  CORTEX_STEP_STATUS_ERROR = 7;  CORTEX_STEP_STATUS_SKIPPING = 11;}
 enum CortexStepSource {  CORTEX_STEP_SOURCE_UNSPECIFIED = 0;  CORTEX_STEP_SOURCE_MANUAL = 1;  CORTEX_STEP_SOURCE_MODEL = 2;  CORTEX_STEP_SOURCE_USER_IMPLICIT = 3;  CORTEX_STEP_SOURCE_USER_EXPLICIT = 4;  CORTEX_STEP_SOURCE_SYSTEM = 5;}
 enum CortexStepCreditReason {  CORTEX_STEP_CREDIT_REASON_UNSPECIFIED = 0;  CORTEX_STEP_CREDIT_REASON_LINT_FIXING_DISCOUNT = 1;}
 enum CortexRequestSource {  CORTEX_REQUEST_SOURCE_UNSPECIFIED = 0;  CORTEX_REQUEST_SOURCE_CASCADE = 1;  CORTEX_REQUEST_SOURCE_USER_IMPLICIT = 2;}
 enum ExecutionAsyncLevel {  EXECUTION_ASYNC_LEVEL_UNSPECIFIED = 0;  EXECUTION_ASYNC_LEVEL_INVOCATION_BLOCKING = 1;  EXECUTION_ASYNC_LEVEL_EXECUTOR_BLOCKING = 2;  EXECUTION_ASYNC_LEVEL_FULL_ASYNC = 3;}
 enum SemanticCodebaseSearchType {  SEMANTIC_CODEBASE_SEARCH_TYPE_UNSPECIFIED = 0;  SEMANTIC_CODEBASE_SEARCH_TYPE_MQUERY = 1;  SEMANTIC_CODEBASE_SEARCH_TYPE_VECTOR_INDEX = 2;}
-enum AcknowledgementType {  ACKNOWLEDGEMENT_TYPE_UNSPECIFIED = 0;  ACKNOWLEDGEMENT_TYPE_ACCEPT = 1;  ACKNOWLEDGEMENT_TYPE_REJECT = 2;  ACKNOWLEDGEMENT_TYPE_STALE = 3;  ACKNOWLEDGEMENT_TYPE_CLEARED = 4;}
-enum InteractiveCascadeEditImportance {  INTERACTIVE_CASCADE_EDIT_IMPORTANCE_UNSPECIFIED = 0;  INTERACTIVE_CASCADE_EDIT_IMPORTANCE_LOW = 1;  INTERACTIVE_CASCADE_EDIT_IMPORTANCE_MEDIUM = 2;  INTERACTIVE_CASCADE_EDIT_IMPORTANCE_HIGH = 3;}
+enum AcknowledgementType {  ACKNOWLEDGEMENT_TYPE_UNSPECIFIED = 0;  ACKNOWLEDGEMENT_TYPE_ACCEPT = 1;  ACKNOWLEDGEMENT_TYPE_REJECT = 2;}
 enum CodeHeuristicFailure {  CODE_HEURISTIC_FAILURE_UNSPECIFIED = 0;  CODE_HEURISTIC_FAILURE_LAZY_COMMENT = 1;  CODE_HEURISTIC_FAILURE_DELETED_LINES = 2;}
 enum BrainEntryType {  BRAIN_ENTRY_TYPE_UNSPECIFIED = 0;  BRAIN_ENTRY_TYPE_PLAN = 1;  BRAIN_ENTRY_TYPE_TASK = 2;}
 enum TaskDeltaType {  TASK_DELTA_TYPE_UNSPECIFIED = 0;  TASK_DELTA_TYPE_ADD = 1;  TASK_DELTA_TYPE_PRUNE = 2;  TASK_DELTA_TYPE_DELETE = 3;  TASK_DELTA_TYPE_UPDATE = 4;  TASK_DELTA_TYPE_MOVE = 5;}
 enum TaskStatus {  TASK_STATUS_UNSPECIFIED = 0;  TASK_STATUS_TODO = 1;  TASK_STATUS_IN_PROGRESS = 2;  TASK_STATUS_DONE = 3;}
-enum CortexTrajectoryType {  CORTEX_TRAJECTORY_TYPE_UNSPECIFIED = 0;  CORTEX_TRAJECTORY_TYPE_USER_MAINLINE = 1;  CORTEX_TRAJECTORY_TYPE_USER_GRANULAR = 2;  CORTEX_TRAJECTORY_TYPE_SUPERCOMPLETE = 3;  CORTEX_TRAJECTORY_TYPE_CASCADE = 4;  CORTEX_TRAJECTORY_TYPE_BACKGROUND_RESEARCH = 5;  CORTEX_TRAJECTORY_TYPE_CHECKPOINT = 6;  CORTEX_TRAJECTORY_TYPE_RETRIEVE_MEMORY = 7;  CORTEX_TRAJECTORY_TYPE_CUSTOM_TOOL = 8;  CORTEX_TRAJECTORY_TYPE_AUTO_CASCADE = 9;  CORTEX_TRAJECTORY_TYPE_AUTO_CASCADE_MANAGER = 10;  CORTEX_TRAJECTORY_TYPE_APPLIER = 11;  CORTEX_TRAJECTORY_TYPE_TOOL_CALL_PROPOSAL = 12;  CORTEX_TRAJECTORY_TYPE_TRAJECTORY_CHOICE = 13;  CORTEX_TRAJECTORY_TYPE_LLM_JUDGE = 14;  CORTEX_TRAJECTORY_TYPE_ARTIFACT_SUMMARY = 19;  CORTEX_TRAJECTORY_TYPE_PASSIVE_CODER = 15;  CORTEX_TRAJECTORY_TYPE_INTERACTIVE_CASCADE = 17;  CORTEX_TRAJECTORY_TYPE_BRAIN_UPDATE = 16;}
 enum FileType {  FILE_TYPE_UNSPECIFIED = 0;  FILE_TYPE_DIRECTORY = 1;  FILE_TYPE_IMAGE = 2;}
 enum TriggerSource {  TRIGGER_SOURCE_UNSPECIFIED = 0;  TRIGGER_SOURCE_VIEWPORT = 1;}
 enum CortexStepCompileTool {  CORTEX_STEP_COMPILE_TOOL_UNSPECIFIED = 0;  CORTEX_STEP_COMPILE_TOOL_PYLINT = 1;}
@@ -1608,16 +1940,15 @@ enum FindResultType {  FIND_RESULT_TYPE_UNSPECIFIED = 0;  FIND_RESULT_TYPE_FILE 
 enum CommandOutputPriority {  COMMAND_OUTPUT_PRIORITY_UNSPECIFIED = 0;  COMMAND_OUTPUT_PRIORITY_TOP = 1;  COMMAND_OUTPUT_PRIORITY_BOTTOM = 2;  COMMAND_OUTPUT_PRIORITY_SPLIT = 3;}
 enum CortexMemorySource {  CORTEX_MEMORY_SOURCE_UNSPECIFIED = 0;  CORTEX_MEMORY_SOURCE_USER = 1;  CORTEX_MEMORY_SOURCE_CASCADE = 2;  CORTEX_MEMORY_SOURCE_AUTO_CASCADE = 3;}
 enum CortexMemoryTrigger {  CORTEX_MEMORY_TRIGGER_UNSPECIFIED = 0;  CORTEX_MEMORY_TRIGGER_ALWAYS_ON = 1;  CORTEX_MEMORY_TRIGGER_MODEL_DECISION = 2;  CORTEX_MEMORY_TRIGGER_MANUAL = 3;  CORTEX_MEMORY_TRIGGER_GLOB = 4;}
+enum RuleSource {  RULE_SOURCE_UNSPECIFIED = 0;  RULE_SOURCE_WORKSPACE = 1;  RULE_SOURCE_SYSTEM = 2;}
 enum MemoryActionType {  MEMORY_ACTION_TYPE_UNSPECIFIED = 0;  MEMORY_ACTION_TYPE_CREATE = 1;  MEMORY_ACTION_TYPE_UPDATE = 2;  MEMORY_ACTION_TYPE_DELETE = 3;}
 enum SectionOverrideMode {  SECTION_OVERRIDE_MODE_UNSPECIFIED = 0;  SECTION_OVERRIDE_MODE_OVERRIDE = 1;  SECTION_OVERRIDE_MODE_APPEND = 2;  SECTION_OVERRIDE_MODE_PREPEND = 3;}
 enum CascadeAgentToolSet {  CASCADE_AGENT_TOOL_SET_UNSPECIFIED = 0;  CASCADE_AGENT_TOOL_SET_ONLY_COMMAND = 1;  CASCADE_AGENT_TOOL_SET_COMMAND_AND_EDITS = 2;  CASCADE_AGENT_TOOL_SET_NO_SEARCH = 3;}
 enum AgenticMixin {  AGENTIC_MIXIN_UNSPECIFIED = 0;  AGENTIC_MIXIN_SMARTLINT = 1;  AGENTIC_MIXIN_PR_REVIEW = 2;}
 enum PassiveCoderRequestSource {  PASSIVE_CODER_REQUEST_SOURCE_UNSPECIFIED = 0;  PASSIVE_CODER_REQUEST_SOURCE_AFTER_RUN_COMMAND = 1;}
-enum ReplaceToolVariant {  REPLACE_TOOL_VARIANT_UNSPECIFIED = 0;  REPLACE_TOOL_VARIANT_REPLACEMENT_CHUNK = 1;  REPLACE_TOOL_VARIANT_SEARCH_REPLACE = 2;  REPLACE_TOOL_VARIANT_APPLY_PATCH = 3;  REPLACE_TOOL_VARIANT_SINGLE_MULTI = 4;}
-enum CheckpointType {  CHECKPOINT_TYPE_UNSPECIFIED = 0;  CHECKPOINT_TYPE_EXPERIMENT = 1;  CHECKPOINT_TYPE_SUBAGENT = 2;}
+enum ReplaceToolVariant {  REPLACE_TOOL_VARIANT_UNSPECIFIED = 0;  REPLACE_TOOL_VARIANT_REPLACEMENT_CHUNK = 1;  REPLACE_TOOL_VARIANT_SEARCH_REPLACE = 2;  REPLACE_TOOL_VARIANT_APPLY_PATCH = 3;  REPLACE_TOOL_VARIANT_SINGLE_MULTI = 4;  REPLACE_TOOL_VARIANT_OPENAI_APPLY_PATCH = 5;}
 enum BrainFilterStrategy {  BRAIN_FILTER_STRATEGY_UNSPECIFIED = 0;  BRAIN_FILTER_STRATEGY_NO_SYSTEM_INJECTED_STEPS = 1;  BRAIN_FILTER_STRATEGY_NO_MEMORIES = 2;}
-enum ExecutorTerminationReason {  EXECUTOR_TERMINATION_REASON_UNSPECIFIED = 0;  EXECUTOR_TERMINATION_REASON_ERROR = 1;  EXECUTOR_TERMINATION_REASON_USER_CANCELED = 2;  EXECUTOR_TERMINATION_REASON_MAX_INVOCATIONS = 3;  EXECUTOR_TERMINATION_REASON_NO_TOOL_CALL = 4;  EXECUTOR_TERMINATION_REASON_HALTED_STEP = 5;}
-enum CortexTrajectorySource {  CORTEX_TRAJECTORY_SOURCE_UNSPECIFIED = 0;  CORTEX_TRAJECTORY_SOURCE_CASCADE_CLIENT = 1;  CORTEX_TRAJECTORY_SOURCE_EXPLAIN_PROBLEM = 2;  CORTEX_TRAJECTORY_SOURCE_REFACTOR_FUNCTION = 3;  CORTEX_TRAJECTORY_SOURCE_EVAL = 4;  CORTEX_TRAJECTORY_SOURCE_EVAL_TASK = 5;  CORTEX_TRAJECTORY_SOURCE_ASYNC_PRR = 6;  CORTEX_TRAJECTORY_SOURCE_ASYNC_CF = 7;  CORTEX_TRAJECTORY_SOURCE_ASYNC_SL = 8;  CORTEX_TRAJECTORY_SOURCE_ASYNC_PRD = 9;  CORTEX_TRAJECTORY_SOURCE_ASYNC_CM = 10;  CORTEX_TRAJECTORY_SOURCE_PASSIVE_CODER = 11;  CORTEX_TRAJECTORY_SOURCE_INTERACTIVE_CASCADE = 12;}
+enum HookAgentAction {  HOOK_AGENT_ACTION_UNSPECIFIED = 0;  HOOK_AGENT_ACTION_PRE_READ_CODE = 1;  HOOK_AGENT_ACTION_POST_READ_CODE = 2;  HOOK_AGENT_ACTION_PRE_WRITE_CODE = 3;  HOOK_AGENT_ACTION_POST_WRITE_CODE = 4;  HOOK_AGENT_ACTION_PRE_MCP_TOOL_USE = 5;  HOOK_AGENT_ACTION_POST_MCP_TOOL_USE = 6;  HOOK_AGENT_ACTION_PRE_RUN_COMMAND = 7;  HOOK_AGENT_ACTION_POST_RUN_COMMAND = 8;  HOOK_AGENT_ACTION_PRE_USER_PROMPT = 9;  HOOK_AGENT_ACTION_POST_CASCADE_RESPONSE = 10;  HOOK_AGENT_ACTION_POST_SETUP_WORKTREE = 11;}
 enum CortexStepManagerFeedbackStatus {  CORTEX_STEP_MANAGER_FEEDBACK_STATUS_UNSPECIFIED = 0;  CORTEX_STEP_MANAGER_FEEDBACK_STATUS_APPROVED = 1;  CORTEX_STEP_MANAGER_FEEDBACK_STATUS_DENIED = 2;  CORTEX_STEP_MANAGER_FEEDBACK_STATUS_ERROR = 3;}
 enum DeployWebAppFileUploadStatus {  DEPLOY_WEB_APP_FILE_UPLOAD_STATUS_UNSPECIFIED = 0;  DEPLOY_WEB_APP_FILE_UPLOAD_STATUS_PENDING = 1;  DEPLOY_WEB_APP_FILE_UPLOAD_STATUS_IN_PROGRESS = 2;  DEPLOY_WEB_APP_FILE_UPLOAD_STATUS_SUCCESS = 3;  DEPLOY_WEB_APP_FILE_UPLOAD_STATUS_FAILURE = 4;}
 enum LintDiffType {  LINT_DIFF_TYPE_UNSPECIFIED = 0;  LINT_DIFF_TYPE_DELETE = 1;  LINT_DIFF_TYPE_INSERT = 2;  LINT_DIFF_TYPE_UNCHANGED = 3;}
@@ -1626,8 +1957,12 @@ enum RunExtensionCodeAutoRunDecision {  RUN_EXTENSION_CODE_AUTO_RUN_DECISION_UNS
 enum TrajectorySearchIdType {  TRAJECTORY_SEARCH_ID_TYPE_UNSPECIFIED = 0;  TRAJECTORY_SEARCH_ID_TYPE_CASCADE_ID = 1;  TRAJECTORY_SEARCH_ID_TYPE_MAINLINE = 2;}
 enum CortexTodoListItemStatus {  CORTEX_TODO_LIST_ITEM_STATUS_UNSPECIFIED = 0;  CORTEX_TODO_LIST_ITEM_STATUS_PENDING = 1;  CORTEX_TODO_LIST_ITEM_STATUS_IN_PROGRESS = 2;  CORTEX_TODO_LIST_ITEM_STATUS_COMPLETED = 3;}
 enum CortexTodoListItemPriority {  CORTEX_TODO_LIST_ITEM_PRIORITY_UNSPECIFIED = 0;  CORTEX_TODO_LIST_ITEM_PRIORITY_LOW = 1;  CORTEX_TODO_LIST_ITEM_PRIORITY_MEDIUM = 2;  CORTEX_TODO_LIST_ITEM_PRIORITY_HIGH = 3;}
-enum ClaudeCodeToolPermissionAction {  CLAUDE_CODE_TOOL_PERMISSION_ACTION_UNSPECIFIED = 0;  CLAUDE_CODE_TOOL_PERMISSION_ACTION_ALLOW = 1;  CLAUDE_CODE_TOOL_PERMISSION_ACTION_DENY = 2;}
+enum EditMode {  EDIT_MODE_UNSPECIFIED = 0;  EDIT_MODE_REPLACE = 1;  EDIT_MODE_INSERT = 2;  EDIT_MODE_DELETE = 3;}
+enum ExecutionStatus {  EXECUTION_STATUS_UNSPECIFIED = 0;  EXECUTION_STATUS_PENDING = 1;  EXECUTION_STATUS_COMPLETED = 2;  EXECUTION_STATUS_ERROR = 3;  EXECUTION_STATUS_TIMED_OUT = 4;}
+enum ExecutorTerminationReason {  EXECUTOR_TERMINATION_REASON_UNSPECIFIED = 0;  EXECUTOR_TERMINATION_REASON_ERROR = 1;  EXECUTOR_TERMINATION_REASON_USER_CANCELED = 2;  EXECUTOR_TERMINATION_REASON_MAX_INVOCATIONS = 3;  EXECUTOR_TERMINATION_REASON_NO_TOOL_CALL = 4;  EXECUTOR_TERMINATION_REASON_HALTED_STEP = 5;  EXECUTOR_TERMINATION_REASON_HOOK_BLOCKED = 6;  EXECUTOR_TERMINATION_REASON_ARENA_INVOCATION_CAP = 7;}
+enum CortexTrajectorySource {  CORTEX_TRAJECTORY_SOURCE_UNSPECIFIED = 0;  CORTEX_TRAJECTORY_SOURCE_CASCADE_CLIENT = 1;  CORTEX_TRAJECTORY_SOURCE_EXPLAIN_PROBLEM = 2;  CORTEX_TRAJECTORY_SOURCE_REFACTOR_FUNCTION = 3;  CORTEX_TRAJECTORY_SOURCE_EVAL = 4;  CORTEX_TRAJECTORY_SOURCE_EVAL_TASK = 5;  CORTEX_TRAJECTORY_SOURCE_ASYNC_PRR = 6;  CORTEX_TRAJECTORY_SOURCE_ASYNC_CF = 7;  CORTEX_TRAJECTORY_SOURCE_ASYNC_SL = 8;  CORTEX_TRAJECTORY_SOURCE_ASYNC_PRD = 9;  CORTEX_TRAJECTORY_SOURCE_ASYNC_CM = 10;  CORTEX_TRAJECTORY_SOURCE_PASSIVE_CODER = 11;  CORTEX_TRAJECTORY_SOURCE_CODE_MAP = 13;  CORTEX_TRAJECTORY_SOURCE_LIFEGUARD = 15;}
 enum CascadeRunStatus {  CASCADE_RUN_STATUS_UNSPECIFIED = 0;  CASCADE_RUN_STATUS_IDLE = 1;  CASCADE_RUN_STATUS_RUNNING = 2;  CASCADE_RUN_STATUS_CANCELING = 3;  CASCADE_RUN_STATUS_BUSY = 4;}
 enum RunCommandAction {  RUN_COMMAND_ACTION_UNSPECIFIED = 0;  RUN_COMMAND_ACTION_CONFIRM = 1;  RUN_COMMAND_ACTION_REJECT = 2;  RUN_COMMAND_ACTION_SKIP = 3;}
-enum McpServerStatus {  MCP_SERVER_STATUS_UNSPECIFIED = 0;  MCP_SERVER_STATUS_PENDING = 1;  MCP_SERVER_STATUS_READY = 2;  MCP_SERVER_STATUS_ERROR = 3;}
+enum ReadUrlContentAction {  READ_URL_CONTENT_ACTION_UNSPECIFIED = 0;  READ_URL_CONTENT_ACTION_ALLOW_ONCE = 1;  READ_URL_CONTENT_ACTION_REJECT = 2;  READ_URL_CONTENT_ACTION_ALWAYS_ALLOW_ORIGIN = 3;}
+enum McpServerStatus {  MCP_SERVER_STATUS_UNSPECIFIED = 0;  MCP_SERVER_STATUS_PENDING = 1;  MCP_SERVER_STATUS_READY = 2;  MCP_SERVER_STATUS_ERROR = 3;  MCP_SERVER_STATUS_NEEDS_OAUTH = 4;}
 enum TrajectoryShareStatus {  TRAJECTORY_SHARE_STATUS_UNSPECIFIED = 0;  TRAJECTORY_SHARE_STATUS_TEAM = 1;}

--- a/protos/exa.diff_action_pb.proto
+++ b/protos/exa.diff_action_pb.proto
@@ -13,16 +13,6 @@ message UnifiedDiffLine {  string text = 1;
 message UnifiedDiff {  repeated exa.diff_action_pb.UnifiedDiffLine lines = 3;
 }
 
-message DiffBlock {  int32 start_line = 1;
-  int32 end_line = 2;
-  exa.diff_action_pb.UnifiedDiff unified_diff = 3;
-  exa.codeium_common_pb.Language from_language = 4;
-  exa.codeium_common_pb.Language to_language = 5;
-}
-
-message DiffList {  repeated exa.diff_action_pb.DiffBlock diffs = 2;
-}
-
 message CharacterDiffChange {  string text = 1;
   exa.diff_action_pb.DiffChangeType type = 2;
 }
@@ -38,6 +28,16 @@ message ComboDiffLine {  string text = 1;
 message ComboDiff {  repeated exa.diff_action_pb.ComboDiffLine lines = 1;
 }
 
-enum UnifiedDiffLineType {  UNIFIED_DIFF_LINE_TYPE_UNSPECIFIED = 0;  UNIFIED_DIFF_LINE_TYPE_INSERT = 1;  UNIFIED_DIFF_LINE_TYPE_DELETE = 2;  UNIFIED_DIFF_LINE_TYPE_UNCHANGED = 3;}
+message DiffBlock {  int32 start_line = 1;
+  int32 end_line = 2;
+  exa.diff_action_pb.UnifiedDiff unified_diff = 3;
+  exa.codeium_common_pb.Language from_language = 4;
+  exa.codeium_common_pb.Language to_language = 5;
+}
+
+message DiffList {  repeated exa.diff_action_pb.DiffBlock diffs = 2;
+}
+
 enum DiffType {  DIFF_TYPE_UNSPECIFIED = 0;  DIFF_TYPE_UNIFIED = 1;  DIFF_TYPE_CHARACTER = 2;  DIFF_TYPE_COMBO = 3;}
+enum UnifiedDiffLineType {  UNIFIED_DIFF_LINE_TYPE_UNSPECIFIED = 0;  UNIFIED_DIFF_LINE_TYPE_INSERT = 1;  UNIFIED_DIFF_LINE_TYPE_DELETE = 2;  UNIFIED_DIFF_LINE_TYPE_UNCHANGED = 3;}
 enum DiffChangeType {  DIFF_CHANGE_TYPE_UNSPECIFIED = 0;  DIFF_CHANGE_TYPE_INSERT = 1;  DIFF_CHANGE_TYPE_DELETE = 2;  DIFF_CHANGE_TYPE_UNCHANGED = 3;}

--- a/protos/exa.language_server_pb.proto
+++ b/protos/exa.language_server_pb.proto
@@ -2,26 +2,20 @@ syntax = "proto3";
 import "exa.codeium_common_pb.proto";
 import "exa.diff_action_pb.proto";
 import "exa.cortex_pb.proto";
-import "exa.index_pb.proto";
 import "exa.chat_pb.proto";
+import "exa.index_pb.proto";
 import "exa.reactive_component_pb.proto";
 import "exa.auto_cascade_common_pb.proto";
 import "exa.knowledge_base_pb.proto";
 import "exa.code_edit.proto";
 import "exa.cascade_plugins_pb.proto";
+import "exa.bug_checker_pb.proto";
 
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/empty.proto";
 
 package exa.language_server_pb;
-message ValidationState {  string uri = 1;
-  string last_acknowledged_state = 2;
-  string current_state = 3;
-  bool last_state_file_nonexistent = 4;
-  bool current_state_file_nonexistent = 5;
-}
-
 message MultilineConfig {  float threshold = 1;
 }
 
@@ -112,6 +106,8 @@ message ProvideCompletionFeedbackRequest {  exa.codeium_common_pb.Metadata metad
   bool is_partial = 12;
   string midstream_autocomplete_text = 13;
   bool has_active_vim_extension = 14;
+  string completion_text = 15;
+  bool is_client_filter_reject = 16;
   exa.codeium_common_pb.ExperimentConfig experiment_config = 9;
 }
 
@@ -129,6 +125,7 @@ message GetStatusRequest {  exa.codeium_common_pb.Metadata metadata = 1;
 }
 
 message GetStatusResponse {  exa.codeium_common_pb.Status status = 1;
+  bool show_review_prompt = 2;
 }
 
 message GetCommandModelConfigsRequest {  exa.codeium_common_pb.Metadata metadata = 1;
@@ -149,7 +146,6 @@ message GetCascadeModelConfigsResponse {  repeated exa.codeium_common_pb.ClientM
 message GetProcessesRequest {}
 
 message GetProcessesResponse {  uint32 lsp_port = 1;
-  uint32 chat_web_server_port = 2;
   uint32 chat_client_port = 3;
 }
 
@@ -170,6 +166,12 @@ message RecordEventRequest {  exa.codeium_common_pb.Metadata metadata = 1;
 }
 
 message RecordEventResponse {}
+
+message RecordSystemMetricsRequest {  exa.codeium_common_pb.Metadata metadata = 1;
+  string system_metrics_json = 2;
+}
+
+message RecordSystemMetricsResponse {}
 
 message CancelRequestRequest {  exa.codeium_common_pb.Metadata metadata = 1;
   uint64 request_id = 2;
@@ -194,33 +196,6 @@ message GetPrimaryApiKeyForDevsOnlyRequest {  string session_token = 1;
 }
 
 message GetPrimaryApiKeyForDevsOnlyResponse {  string api_key = 1;
-}
-
-message ClusteredSearchRequest {  exa.codeium_common_pb.Metadata metadata = 4;
-  string query = 1;
-  uint32 num_results = 2;
-  uint32 num_clusters = 3;
-}
-
-message SearchResult {  int64 embedding_id = 1;
-  string absolute_path_migrate_me_to_uri = 2;
-  string absolute_uri = 7;
-  repeated exa.codeium_common_pb.WorkspacePath workspace_paths = 3;
-  exa.codeium_common_pb.EmbeddingMetadata embedding_metadata = 4;
-  float similarity_score = 5;
-  exa.codeium_common_pb.CodeContextItem code_context_item = 6;
-}
-
-message SearchResultCluster {  repeated exa.language_server_pb.SearchResult search_results = 1;
-  string representative_path = 2;
-  string description = 3;
-  float mean_similarity_score = 4;
-  string search_id = 5;
-  string result_id = 6;
-}
-
-message ClusteredSearchResponse {  repeated exa.language_server_pb.SearchResultCluster clusters = 1;
-  string search_id = 2;
 }
 
 message WellSupportedLanguagesRequest {}
@@ -324,6 +299,71 @@ message HandleStreamingTabResponse {  string completion_id = 1;
   string raw_text = 16;
   uint64 closest_changed_line = 11;
   string request_uid = 17;
+  string old_str = 18;
+}
+
+message HandleStreamingTabV2Request {  exa.codeium_common_pb.Metadata metadata = 1;
+  exa.codeium_common_pb.Document document = 2;
+  exa.codeium_common_pb.EditorOptions editor_options = 3;
+  repeated exa.codeium_common_pb.CodeDiagnostic diagnostics = 5;
+  exa.codeium_common_pb.SupercompleteTriggerCondition supercomplete_trigger_condition = 6;
+  string clipboard_entry = 7;
+  repeated exa.codeium_common_pb.IntellisenseSuggestion intellisense_suggestions = 8;
+  repeated exa.codeium_common_pb.Document other_documents = 9;
+  exa.chat_pb.DeepWikiContext deep_wiki_context_v2 = 12;
+  repeated exa.cortex_pb.CortexTrajectoryStep predictive_trajectory_steps = 11;
+  bool disable_supercomplete = 13;
+  bool disable_tab_jump = 14;
+}
+
+message SideHintRender {}
+
+message InlineHintRender {}
+
+message Diff {  string path = 1;
+  uint64 selection_start_line = 2;
+  uint64 selection_end_line = 3;
+  exa.diff_action_pb.CharacterDiff character_diff = 4;
+  exa.codeium_common_pb.DocumentPosition cursor_position = 5;
+  string old_str = 6;
+  exa.diff_action_pb.UnifiedDiff unified_diff = 9;
+  exa.language_server_pb.SideHintRender side_hint_render = 7;
+  exa.language_server_pb.InlineHintRender inline_hint_render = 8;
+}
+
+message TabJump {  string path = 1;
+  exa.codeium_common_pb.DocumentPosition jump_position = 2;
+  bool is_import = 3;
+}
+
+message NoOp {}
+
+message HandleStreamingTabV2Response {  string completion_id = 1;
+  string prompt_id = 2;
+  string request_uid = 3;
+  exa.codeium_common_pb.SuperCompleteFilterReason filter_reason = 4;
+  exa.codeium_common_pb.StopReason stop_reason = 5;
+  exa.language_server_pb.TabRequestInfo request_info = 6;
+  exa.language_server_pb.Diff diff = 7;
+  exa.language_server_pb.TabJump tab_jump = 8;
+  exa.language_server_pb.NoOp noop = 9;
+}
+
+message TerminalCommandConversationEntry {  string user_prompt = 1;
+  string generated_command = 2;
+  string explanation = 3;
+}
+
+message HandleStreamingTerminalCommandRequest {  exa.codeium_common_pb.Metadata metadata = 1;
+  string command_text = 2;
+  exa.codeium_common_pb.TerminalCommandData terminal_command_data = 3;
+  exa.codeium_common_pb.Model model = 4;
+  repeated exa.language_server_pb.TerminalCommandConversationEntry conversation_history = 5;
+}
+
+message HandleStreamingTerminalCommandResponse {  string completion_id = 1;
+  string command = 2;
+  string explanation = 3;
 }
 
 message UploadRecentCommandsRequest {  exa.codeium_common_pb.Metadata metadata = 1;
@@ -376,12 +416,6 @@ message SetPinnedContextRequest {  exa.codeium_common_pb.Metadata metadata = 1;
 }
 
 message SetPinnedContextResponse {}
-
-message GetMcpServerTemplatesRequest {  exa.codeium_common_pb.Metadata metadata = 1;
-}
-
-message GetMcpServerTemplatesResponse {  repeated exa.codeium_common_pb.McpServerTemplate templates = 1;
-}
 
 message AddTrackedWorkspaceRequest {  string workspace = 1;
 }
@@ -458,6 +492,7 @@ message GetMatchingContextScopeItemsRequest {  exa.codeium_common_pb.Metadata me
   int32 max_items = 5;
   bool case_insensitive = 6;
   string repo_filter = 8;
+  bool enable_path_resolution = 10;
 }
 
 message GetMatchingContextScopeItemsResponse {  repeated exa.codeium_common_pb.ContextScopeItem items = 1;
@@ -487,6 +522,17 @@ message GetDeepWikiResponse {  exa.language_server_pb.RawGetChatMessageResponse 
   bool is_article_done = 5;
 }
 
+message CheckUserMessageRateLimitRequest {  exa.codeium_common_pb.Metadata metadata = 1;
+  string model_uid = 3;
+}
+
+message CheckUserMessageRateLimitResponse {  bool has_capacity = 1;
+  string message = 2;
+  int32 messages_remaining = 3;
+  int32 max_messages = 4;
+  int64 resets_in_seconds = 5;
+}
+
 message GetMessageTokenCountRequest {  string chat_message = 1;
   exa.codeium_common_pb.Model requested_model_id = 2;
 }
@@ -509,6 +555,15 @@ message RecordChatPanelSessionRequest {  exa.codeium_common_pb.Metadata metadata
 }
 
 message RecordChatPanelSessionResponse {}
+
+message CheckChatCapacityRequest {  exa.codeium_common_pb.Metadata metadata = 1;
+  string model_uid = 3;
+}
+
+message CheckChatCapacityResponse {  bool has_capacity = 1;
+  string message = 2;
+  int32 active_sessions = 3;
+}
 
 message ShouldEnableUnleashRequest {}
 
@@ -554,18 +609,6 @@ message GetWorkspaceInfosResponse {  string home_dir_path = 1;
   string home_dir_uri = 3;
 }
 
-message CreateWorktreeRequest {  exa.codeium_common_pb.Metadata metadata = 1;
-  string repo_path = 2;
-  string base_branch_name = 3;
-  exa.codeium_common_pb.PlanInfo plan_info = 4;
-  repeated exa.codeium_common_pb.TextOrScopeItem items = 5;
-  repeated exa.codeium_common_pb.ImageData images = 6;
-}
-
-message CreateWorktreeResponse {  string worktree_path = 1;
-  string worktree_name = 2;
-}
-
 message GenerateCommitMessageRequest {  exa.codeium_common_pb.Metadata metadata = 1;
   exa.codeium_common_pb.PlanInfo plan_info = 2;
 }
@@ -593,15 +636,6 @@ message RecordCommitMessageSaveRequest {  exa.codeium_common_pb.Metadata metadat
 
 message RecordCommitMessageSaveResponse {}
 
-message UpdatePRForWorktreeRequest {  string worktree_fs_path = 1;
-  string commit_message = 2;
-  string title = 3;
-  string body = 4;
-}
-
-message UpdatePRForWorktreeResponse {  string pr_url = 1;
-}
-
 message SendActionToChatPanelRequest {  string action_type = 1;
   repeated bytes payload = 2;
 }
@@ -619,21 +653,14 @@ message SetUserSettingsRequest {  exa.codeium_common_pb.UserSettings user_settin
 message SetUserSettingsResponse {  exa.codeium_common_pb.UserSettings user_settings = 1;
 }
 
+message GetDefaultWebOriginsRequest {}
+
+message GetDefaultWebOriginsResponse {  repeated string default_origins = 1;
+}
+
 message GetDebugDiagnosticsRequest {}
 
 message GetDebugDiagnosticsResponse {  exa.codeium_common_pb.LanguageServerDiagnostics language_server_diagnostics = 1;
-}
-
-message GetUserAnalyticsSummaryRequest {  exa.codeium_common_pb.Metadata metadata = 1;
-  string time_zone = 2;
-  google.protobuf.Timestamp start_timestamp = 3;
-  google.protobuf.Timestamp end_timestamp = 4;
-}
-
-message GetUserAnalyticsSummaryResponse {  exa.codeium_common_pb.CompletionStatistics completion_statistics = 1;
-  repeated exa.codeium_common_pb.CompletionByDateEntry completions_by_day = 2;
-  repeated exa.codeium_common_pb.CompletionByLanguageEntry completions_by_language = 3;
-  repeated exa.codeium_common_pb.ChatStatsByModelEntry chats_by_model = 4;
 }
 
 message GetUserStatusRequest {  exa.codeium_common_pb.Metadata metadata = 1;
@@ -694,49 +721,6 @@ message ExitRequest {}
 
 message ExitResponse {}
 
-message CodeTheme {  string background = 1;
-  string text = 2;
-  string whitespace = 3;
-  string other = 4;
-  string literal = 5;
-  string literal_string = 6;
-  string number = 7;
-  string operator = 8;
-  string punctuation = 9;
-  string generic = 10;
-  string name = 11;
-  string keyword = 12;
-  string comment = 13;
-  string error = 14;
-}
-
-message RenderConfig {  string font_family = 1;
-  string theme_name = 2;
-  float line_height = 3;
-  exa.language_server_pb.EditorThemeType theme_type = 4;
-  float font_size = 5;
-  exa.language_server_pb.CodeTheme theme = 6;
-  string shortcut = 7;
-}
-
-message RenderRequestMetadata {  string language = 6;
-}
-
-message RenderInsertionSideHintRequest {  exa.diff_action_pb.CharacterDiff diff = 1;
-  exa.language_server_pb.RenderConfig config = 2;
-  exa.language_server_pb.RenderRequestMetadata metadata = 3;
-}
-
-message RenderedSideHintDisplayOptions {  int32 width = 1;
-  int32 height = 2;
-  float dpmm = 3;
-  float scale = 4;
-}
-
-message RenderInsertionSideHintResponse {  string data = 1;
-  exa.language_server_pb.RenderedSideHintDisplayOptions display_options = 2;
-}
-
 message ResetOnboardingRequest {  bool clear_history = 1;
 }
 
@@ -781,6 +765,11 @@ message GetUserMemoriesRequest {}
 message GetUserMemoriesResponse {  repeated exa.cortex_pb.CortexMemory memories = 1;
 }
 
+message RefreshCustomizationRequest {  exa.codeium_common_pb.RefreshCustomizationType config_type = 1;
+}
+
+message RefreshCustomizationResponse {}
+
 message GetConversationTagsRequest {  exa.codeium_common_pb.Metadata metadata = 1;
 }
 
@@ -801,16 +790,25 @@ message StartCascadeRequest {  exa.codeium_common_pb.Metadata metadata = 1;
   exa.cortex_pb.BaseTrajectoryIdentifier base_trajectory_identifier = 3;
   exa.cortex_pb.CortexTrajectorySource source = 4;
   exa.cortex_pb.CortexTrajectoryType trajectory_type = 5;
+  uint32 start_arena = 6;
+  bool git_worktree = 7;
   exa.codeium_common_pb.ExperimentConfig experiment_config = 2;
+  exa.cortex_pb.ArenaModeInfo arena_mode_info = 8;
 }
 
 message StartCascadeResponse {  string cascade_id = 1;
+  repeated string arena_cascade_ids = 2;
 }
 
 message CancelCascadeInvocationRequest {  string cascade_id = 1;
 }
 
 message CancelCascadeInvocationResponse {}
+
+message CancelCascadeInvocationAndWaitRequest {  string cascade_id = 1;
+}
+
+message CancelCascadeInvocationAndWaitResponse {}
 
 message CancelCascadeStepsRequest {  string cascade_id = 1;
   repeated uint32 step_indices = 2;
@@ -831,10 +829,71 @@ message SendUserCascadeMessageRequest {  exa.codeium_common_pb.Metadata metadata
 
 message SendUserCascadeMessageResponse {}
 
+message BranchCascadeRequest {  exa.codeium_common_pb.Metadata metadata = 1;
+  string base_cascade_id = 2;
+  repeated exa.codeium_common_pb.TextOrScopeItem items = 3;
+  repeated exa.codeium_common_pb.ImageData images = 4;
+  exa.cortex_pb.CascadeConfig cascade_config = 5;
+  repeated string recipe_ids = 6;
+  bool blocking = 7;
+  repeated exa.cortex_pb.CortexTrajectoryStep additional_steps = 8;
+  int32 branch_from_step_index = 9;
+}
+
+message BranchCascadeResponse {  string new_cascade_id = 1;
+}
+
+message QueueCascadeMessageRequest {  exa.codeium_common_pb.Metadata metadata = 1;
+  string cascade_id = 2;
+  repeated exa.codeium_common_pb.TextOrScopeItem items = 3;
+  repeated exa.codeium_common_pb.ImageData images = 4;
+  exa.cortex_pb.CascadeConfig cascade_config = 5;
+}
+
+message QueueCascadeMessageResponse {  string queue_id = 1;
+}
+
+message InterruptWithQueuedMessageRequest {  exa.codeium_common_pb.Metadata metadata = 1;
+  string cascade_id = 2;
+  string queue_id = 3;
+}
+
+message InterruptWithQueuedMessageResponse {}
+
+message RemoveFromQueueRequest {  exa.codeium_common_pb.Metadata metadata = 1;
+  string cascade_id = 2;
+  string queue_id = 3;
+}
+
+message RemoveFromQueueResponse {  bool removed = 1;
+}
+
+message MoveQueuedMessageRequest {  exa.codeium_common_pb.Metadata metadata = 1;
+  string cascade_id = 2;
+  string queue_id = 3;
+  int32 to_index = 4;
+}
+
+message MoveQueuedMessageResponse {}
+
+message SyncExploreAgentRunRequest {  exa.codeium_common_pb.Metadata metadata = 1;
+  string cascade_id = 2;
+  string query_id = 3;
+  int32 message_index = 4;
+  repeated exa.codeium_common_pb.TextOrScopeItem items = 5;
+  string title = 8;
+  string response = 6;
+  bool is_complete = 7;
+}
+
+message SyncExploreAgentRunResponse {  int32 message_index = 1;
+}
+
 message RevertToCascadeStepRequest {  exa.codeium_common_pb.Metadata metadata = 3;
   string cascade_id = 1;
   int32 step_index = 2;
   exa.codeium_common_pb.ExperimentConfig experiment_config = 4;
+  bool keep_changes = 5;
 }
 
 message RevertToCascadeStepResponse {  exa.cortex_pb.RevertMetadata metadata = 1;
@@ -851,21 +910,6 @@ message CodeEditRevertPreview {  string file_uri = 1;
 }
 
 message GetRevertPreviewResponse {  repeated exa.language_server_pb.CodeEditRevertPreview code_edit_previews = 1;
-}
-
-message UnrevertToCascadeStepRequest {  exa.codeium_common_pb.Metadata metadata = 1;
-  string cascade_id = 2;
-  int32 num_steps = 3;
-}
-
-message UnrevertToCascadeStepResponse {  exa.cortex_pb.UnrevertMetadata metadata = 1;
-}
-
-message GetUnrevertPreviewRequest {  string cascade_id = 1;
-  int32 num_steps = 2;
-}
-
-message GetUnrevertPreviewResponse {  repeated exa.language_server_pb.CodeEditRevertPreview code_edit_previews = 1;
 }
 
 message RecordUserStepSnapshotRequest {  string cascade_id = 1;
@@ -906,7 +950,25 @@ message AcknowledgeCascadeCodeEditResponse {}
 message GetCodeValidationStatesRequest {  string cascade_id = 1;
 }
 
+message ValidationState {  string uri = 1;
+  string last_acknowledged_state = 2;
+  string current_state = 3;
+  bool last_state_file_nonexistent = 4;
+  bool current_state_file_nonexistent = 5;
+  bool is_notebook = 6;
+  int32 cell_index = 7;
+}
+
 message GetCodeValidationStatesResponse {  repeated exa.language_server_pb.ValidationState states = 1;
+}
+
+message ResolveWorktreeChangesRequest {  string cascade_id = 1;
+  repeated string uris = 2;
+  exa.language_server_pb.ResolveWorktreeChangesMode mode = 3;
+  bool fail_on_conflicts = 4;
+}
+
+message ResolveWorktreeChangesResponse {  bool had_conflicts = 1;
 }
 
 message DeleteCascadeTrajectoryRequest {  string cascade_id = 1;
@@ -921,10 +983,37 @@ message RenameCascadeTrajectoryRequest {  string cascade_id = 1;
 message RenameCascadeTrajectoryResponse {}
 
 message InitializeCascadePanelStateRequest {  exa.codeium_common_pb.Metadata metadata = 1;
-  exa.codeium_common_pb.UserStatus user_status = 2;
+  bool workspace_trusted = 3;
 }
 
 message InitializeCascadePanelStateResponse {}
+
+message UpdatePanelStateWithUserStatusRequest {  exa.codeium_common_pb.Metadata metadata = 1;
+  exa.codeium_common_pb.UserStatus user_status = 2;
+}
+
+message UpdatePanelStateWithUserStatusResponse {}
+
+message UpdateWorkspaceTrustRequest {  exa.codeium_common_pb.Metadata metadata = 1;
+  bool workspace_trusted = 2;
+}
+
+message UpdateWorkspaceTrustResponse {}
+
+message SpawnArenaModeMidConversationRequest {  exa.codeium_common_pb.Metadata metadata = 1;
+  string cascade_id = 2;
+  uint32 count = 3;
+}
+
+message SpawnArenaModeMidConversationResponse {  repeated string cascade_ids = 1;
+}
+
+message ConvergeArenaCascadesRequest {  exa.codeium_common_pb.Metadata metadata = 1;
+  string target_cascade_id = 2;
+}
+
+message ConvergeArenaCascadesResponse {  repeated string converged_cascade_ids = 1;
+}
 
 message ForceBackgroundResearchRefreshRequest {  exa.codeium_common_pb.Metadata metadata = 1;
   string mainline_trajectory_id = 2;
@@ -948,8 +1037,50 @@ message RefreshMcpServersResponse {}
 message GetMcpServerStatesRequest {}
 
 message GetMcpServerStatesResponse {  repeated exa.cortex_pb.McpServerState states = 1;
-  bool is_loading = 2;
 }
+
+message GetMcpPromptRequest {  string server_name = 1;
+  string prompt_name = 2;
+  map<string, string> arguments = 3;
+}
+
+message McpPromptMessageContent {  string text = 1;
+  exa.cortex_pb.McpResourceContent resource = 2;
+}
+
+message McpPromptMessage {  string role = 1;
+  repeated exa.language_server_pb.McpPromptMessageContent content = 2;
+}
+
+message GetMcpPromptResponse {  repeated exa.language_server_pb.McpPromptMessage messages = 1;
+}
+
+message SaveMcpServerToConfigFileRequest {  string server_id = 1;
+  string template_json = 2;
+  bool shallow_refresh = 3;
+}
+
+message SaveMcpServerToConfigFileResponse {  string error_message = 2;
+}
+
+message UpdateMcpServerInConfigFileRequest {  string server_id = 1;
+}
+
+message UpdateMcpServerInConfigFileResponse {  string error_message = 2;
+}
+
+message ToggleMcpToolRequest {  string server_id = 1;
+  string tool_name = 2;
+}
+
+message ToggleMcpToolResponse {  string error_message = 1;
+}
+
+message DismissCodeMapSuggestionRequest {  string cascade_id = 1;
+  string suggestion_id = 2;
+}
+
+message DismissCodeMapSuggestionResponse {}
 
 message StreamTerminalShellCommandResponse {}
 
@@ -1014,41 +1145,6 @@ message UpdateAutoCascadeGithubCredentialsRequest {  exa.codeium_common_pb.Metad
 
 message UpdateAutoCascadeGithubCredentialsResponse {}
 
-message SendUserAutoCascadeMessageRequest {  exa.codeium_common_pb.Metadata metadata = 1;
-  repeated exa.codeium_common_pb.TextOrScopeItem items = 2;
-  repeated exa.codeium_common_pb.ImageData images = 3;
-  string session_key = 4;
-}
-
-message SendUserAutoCascadeMessageResponse {  string session_key = 1;
-}
-
-message DeleteAutoCascadeSessionRequest {  exa.codeium_common_pb.Metadata metadata = 1;
-  string session_key = 2;
-}
-
-message DeleteAutoCascadeSessionResponse {}
-
-message CheckoutAutoCascadeSessionBranchRequest {  repeated exa.auto_cascade_common_pb.GitRepoInfo git_repo_infos = 1;
-  repeated string workspace_uris = 2;
-}
-
-message CheckoutAutoCascadeSessionBranchResponse {}
-
-message DiffAutoCascadeSessionBranchRequest {  repeated exa.auto_cascade_common_pb.GitRepoInfo git_repo_infos = 1;
-  repeated string workspace_uris = 2;
-}
-
-message DiffAutoCascadeSessionBranchResponse {  repeated exa.language_server_pb.ValidationState validation_states = 1;
-  bool can_merge = 2;
-}
-
-message MergeAutoCascadeSessionBranchRequest {  repeated exa.auto_cascade_common_pb.GitRepoInfo git_repo_infos = 1;
-  repeated string workspace_uris = 2;
-}
-
-message MergeAutoCascadeSessionBranchResponse {}
-
 message GetAllWorkflowsRequest {}
 
 message GetAllWorkflowsResponse {  repeated exa.cortex_pb.WorkflowSpec workflows = 2;
@@ -1064,100 +1160,22 @@ message CopyBuiltinWorkflowToWorkspaceResponse {  exa.cortex_pb.WorkflowSpec wor
 message GetAllRulesRequest {}
 
 message GetAllRulesResponse {  repeated exa.cortex_pb.CortexMemory memories = 2;
+  repeated exa.cortex_pb.CortexSkill skills = 3;
 }
 
-message GetAllClaudeCodeAgentsRequest {  exa.language_server_pb.ClaudeCodeAgentType agent_type = 1;
-  string workspace_uri = 2;
+message GetAllSkillsRequest {}
+
+message GetAllSkillsResponse {  repeated exa.cortex_pb.CortexSkill skills = 1;
 }
 
-message ClaudeCodeAgent {  string name = 1;
-  string description = 2;
-  string tools = 3;
-  string content = 4;
-  string file_path = 5;
-  string color = 6;
-  string model = 7;
+message GetAllPlansRequest {}
+
+message PlanFileInfo {  string path = 1;
+  string title = 2;
+  string description = 3;
 }
 
-message GetAllClaudeCodeAgentsResponse {  repeated exa.language_server_pb.ClaudeCodeAgent agents = 1;
-}
-
-message CreateClaudeCodeAgentRequest {  exa.language_server_pb.ClaudeCodeAgent agent = 1;
-  exa.language_server_pb.ClaudeCodeAgentType agent_type = 2;
-  string workspace_uri = 3;
-}
-
-message CreateClaudeCodeAgentResponse {}
-
-message DeleteClaudeCodeAgentRequest {  string name = 1;
-  exa.language_server_pb.ClaudeCodeAgentType agent_type = 2;
-  string workspace_uri = 3;
-}
-
-message DeleteClaudeCodeAgentResponse {}
-
-message GetAllClaudeCodeMemoriesRequest {  exa.language_server_pb.ClaudeCodeAgentType memory_type = 1;
-  string workspace_uri = 2;
-}
-
-message ClaudeCodeMemory {  string content = 1;
-  string filepath = 2;
-}
-
-message GetAllClaudeCodeMemoriesResponse {  repeated exa.language_server_pb.ClaudeCodeMemory memories = 1;
-}
-
-message CreateClaudeCodeMemoriesRequest {  exa.language_server_pb.ClaudeCodeMemory memory = 1;
-  exa.language_server_pb.ClaudeCodeAgentType memory_type = 2;
-  string workspace_uri = 3;
-}
-
-message CreateClaudeCodeMemoriesResponse {}
-
-message DeleteClaudeCodeMemoriesRequest {  exa.language_server_pb.ClaudeCodeAgentType memory_type = 1;
-  string workspace_uri = 2;
-}
-
-message DeleteClaudeCodeMemoriesResponse {}
-
-message GetClaudeCodeSettingsRequest {}
-
-message McpServers {  repeated string mcp_server_content = 1;
-}
-
-message ClaudeCodePermissions {  repeated string allow = 1;
-  repeated string deny = 2;
-}
-
-message ClaudeCodeSettings {  exa.language_server_pb.McpServers servers = 1;
-  exa.language_server_pb.ClaudeCodePermissions permissions = 2;
-}
-
-message GetClaudeCodeSettingsResponse {  exa.language_server_pb.ClaudeCodeSettings settings = 1;
-}
-
-message EditClaudeCodeSettingsRequest {  exa.language_server_pb.ClaudeCodeSettings settings = 1;
-}
-
-message EditClaudeCodeSettingsResponse {}
-
-message GetClaudeCodeProjectMcpRequest {  string workspace_uri = 1;
-}
-
-message GetClaudeCodeProjectMcpResponse {  exa.language_server_pb.McpServers servers = 1;
-}
-
-message EditClaudeCodeProjectMcpRequest {  string workspace_uri = 1;
-  exa.language_server_pb.McpServers servers = 2;
-}
-
-message EditClaudeCodeProjectMcpResponse {}
-
-message ListMcpResourcesRequest {  string server_name = 1;
-  string query = 2;
-}
-
-message ListMcpResourcesResponse {  repeated exa.codeium_common_pb.McpResourceItem resources = 1;
+message GetAllPlansResponse {  repeated exa.language_server_pb.PlanFileInfo plans = 1;
 }
 
 message UpdateEnterpriseExperimentsFromUrlRequest {  string portal_url = 1;
@@ -1195,12 +1213,6 @@ message RecordUserGrepRequest {  string query = 1;
 }
 
 message RecordUserGrepResponse {}
-
-message GetGithubPullRequestInfoRequest {  exa.codeium_common_pb.Metadata metadata = 1;
-}
-
-message GetGithubPullRequestInfoResponse {  repeated exa.auto_cascade_common_pb.GithubPullRequestInfo pull_request_infos = 1;
-}
 
 message GetGithubPullRequestSearchInfoRequest {  exa.codeium_common_pb.Metadata metadata = 1;
   string query = 2;
@@ -1300,26 +1312,21 @@ message ReplayGroundTruthTrajectoryRequest {  exa.codeium_common_pb.Metadata met
 message ReplayGroundTruthTrajectoryResponse {  exa.cortex_pb.CortexTrajectory trajectory = 1;
 }
 
-message RecordInteractiveCascadeFeedbackRequest {  exa.codeium_common_pb.Metadata metadata = 1;
-  string cascade_id = 2;
-  int32 step_index = 3;
-  int32 chunk_index = 4;
-  exa.cortex_pb.AcknowledgementType acknowledgement_type = 5;
+message MountCascadeFilesystemRequest {  string cascade_id = 1;
 }
 
-message RecordInteractiveCascadeFeedbackResponse {}
+message MountCascadeFilesystemResponse {}
+
+message UnmountCascadeFilesystemRequest {  string cascade_id = 1;
+}
+
+message UnmountCascadeFilesystemResponse {}
 
 message LogCascadeSessionRequest {  exa.codeium_common_pb.Metadata metadata = 1;
   repeated string workspace_paths = 2;
 }
 
 message LogCascadeSessionResponse {}
-
-message GetCascadeNuxesRequest {  exa.codeium_common_pb.Metadata metadata = 1;
-}
-
-message GetCascadeNuxesResponse {  repeated exa.codeium_common_pb.CascadeNUXConfig nuxes = 1;
-}
 
 message GetTranscriptionRequest {  exa.codeium_common_pb.Metadata metadata = 1;
   bytes audio_data = 2;
@@ -1341,7 +1348,7 @@ message GenerateVibeAndReplaceStreamingRequest {  exa.codeium_common_pb.Metadata
   string search_options_text = 5;
   repeated exa.language_server_pb.VibeAndReplaceFile files = 6;
   string cascade_id = 7;
-  exa.codeium_common_pb.Model model_for_generation = 8;
+  string model_uid_for_generation = 9;
 }
 
 message VibeAndReplaceData {  string request_id = 1;
@@ -1355,12 +1362,140 @@ message VibeAndReplaceData {  string request_id = 1;
 message GenerateVibeAndReplaceStreamingResponse {  exa.language_server_pb.VibeAndReplaceData vibe_and_replace_data = 1;
 }
 
-message ClaudeCodeMCPRequest {  string request = 1;
-  string tool = 2;
-  string cascade_session_id = 3;
+message GetCodeMapsForReposRequest {  repeated string repo_paths = 1;
 }
 
-message ClaudeCodeMCPResponse {  string response = 1;
+message GetCodeMapsForReposResponse {  repeated string code_maps = 1;
+}
+
+message GetCodeMapsForFileRequest {  string file_path = 1;
+}
+
+message GetCodeMapsForFileResponse {  repeated string code_maps = 1;
+}
+
+message GenerateCodeMapRequest {  string prompt = 1;
+  string mode = 2;
+  string source = 3;
+}
+
+message Success {  string code_map_json = 1;
+}
+
+message GenerateCodeMapResponse {  string updates_json = 1;
+  exa.language_server_pb.Success success = 2;
+  string status = 3;
+}
+
+message BranchCascadeAndGenerateCodeMapRequest {  string cascade_id = 1;
+  string prompt = 2;
+  string source = 3;
+  string editing_codemap_id = 4;
+  string mode = 5;
+}
+
+message Success {  string code_map_json = 1;
+  string new_cascade_id = 2;
+}
+
+message BranchCascadeAndGenerateCodeMapResponse {  string updates_json = 1;
+  exa.language_server_pb.Success success = 2;
+  string status = 3;
+}
+
+message ShareCodeMapRequest {  exa.codeium_common_pb.Metadata metadata = 1;
+  string code_map_json = 2;
+  string file_name = 3;
+}
+
+message ShareCodeMapResponse {  string share_url = 1;
+}
+
+message GetSharedCodeMapRequest {  exa.codeium_common_pb.Metadata metadata = 1;
+  string code_map_id = 2;
+  int32 time_since_install = 3;
+}
+
+message GetSharedCodeMapResponse {  string code_map_data = 1;
+}
+
+message GetCodeMapSuggestionsRequest {  exa.codeium_common_pb.Metadata metadata = 1;
+  repeated string navigation_history = 2;
+}
+
+message GetCodeMapSuggestionsResponse {  repeated exa.cortex_pb.CodeMapSuggestion suggestions = 1;
+}
+
+message UpdateCodeMapMetadataRequest {  string id = 1;
+  bool starred = 2;
+  bool archived = 3;
+}
+
+message UpdateCodeMapMetadataResponse {}
+
+message SaveCodeMapFromJsonRequest {  exa.codeium_common_pb.Metadata metadata = 1;
+  string code_map_json = 2;
+}
+
+message SaveCodeMapFromJsonResponse {  string code_map_json = 1;
+}
+
+message CheckBugsRequest {  exa.codeium_common_pb.Metadata metadata = 1;
+  string diff = 2;
+  string repo_name = 3;
+  string commit_hash = 4;
+  string author_name = 5;
+  string model = 6;
+  string commit_message = 7;
+  int32 lines_changed = 8;
+  repeated string user_rules = 9;
+  string method = 10;
+  string symbol_context = 11;
+  string check_type = 12;
+  string base_ref = 13;
+  string git_root = 14;
+}
+
+message CheckBugsResponse {  repeated exa.bug_checker_pb.Bug bugs = 1;
+  string bug_check_id = 2;
+  string method_used = 3;
+  string model_used = 4;
+  string playgrounds = 5;
+  exa.codeium_common_pb.Model model_id = 6;
+  string agent_version = 7;
+}
+
+message GetLifeguardConfigRequest {  exa.codeium_common_pb.Metadata metadata = 1;
+}
+
+message GetLifeguardConfigResponse {  exa.codeium_common_pb.LifeguardConfig config = 1;
+}
+
+message SubmitBugReportRequest {  exa.codeium_common_pb.Metadata metadata = 1;
+  string description = 2;
+  string bug_type = 3;
+  string diagnostics_json = 4;
+  bytes screenshot = 5;
+  string tab_info = 6;
+  string other = 7;
+}
+
+message SubmitBugReportResponse {  string message_link = 1;
+}
+
+message OnEditRequest {  exa.codeium_common_pb.Document initial_document = 1;
+  exa.codeium_common_pb.Document final_document = 2;
+  exa.language_server_pb.EditSource source = 3;
+}
+
+message OnEditResponse {}
+
+message GetSystemPromptAndToolsRequest {  exa.codeium_common_pb.Metadata metadata = 1;
+  exa.cortex_pb.CascadeConfig cascade_config = 2;
+}
+
+message GetSystemPromptAndToolsResponse {  string system_prompt = 1;
+  repeated exa.chat_pb.ChatToolDefinition tool_definitions = 2;
 }
 
 enum CodeiumState {  CODEIUM_STATE_UNSPECIFIED = 0;  CODEIUM_STATE_INACTIVE = 1;  CODEIUM_STATE_PROCESSING = 2;  CODEIUM_STATE_SUCCESS = 3;  CODEIUM_STATE_WARNING = 4;  CODEIUM_STATE_ERROR = 5;}
@@ -1369,10 +1504,10 @@ enum TabRequestSource {  TAB_REQUEST_SOURCE_UNSPECIFIED = 0;  TAB_REQUEST_SOURCE
 enum FileType {  FILE_TYPE_UNSPECIFIED = 0;  FILE_TYPE_FILE = 1;  FILE_TYPE_DIRECTORY = 2;  FILE_TYPE_SYMLINK = 3;}
 enum IdeAction {  IDE_ACTION_UNSPECIFIED = 0;  IDE_ACTION_SAVE = 1;  IDE_ACTION_SELECTION_CHANGED = 2;  IDE_ACTION_VISIBLE_RANGES_CHANGED = 3;  IDE_ACTION_ACTIVE_EDITOR_CHANGED = 4;  IDE_ACTION_STARTUP = 5;}
 enum ContextSuggestionSource {  CONTEXT_SUGGESTION_SOURCE_UNSPECIFIED = 0;  CONTEXT_SUGGESTION_SOURCE_COMMIT_HISTORY = 1;  CONTEXT_SUGGESTION_SOURCE_CURRENT_PLAN = 2;}
-enum EditorThemeType {  EDITOR_THEME_TYPE_UNSPECIFIED = 0;  EDITOR_THEME_TYPE_LIGHT = 1;  EDITOR_THEME_TYPE_DARK = 2;  EDITOR_THEME_TYPE_HIGH_CONTRAST = 3;  EDITOR_THEME_TYPE_HIGH_CONTRAST_LIGHT = 4;}
 enum CodeRevertActionType {  CODE_REVERT_ACTION_TYPE_UNSPECIFIED = 0;  CODE_REVERT_ACTION_TYPE_MODIFY = 1;  CODE_REVERT_ACTION_TYPE_CREATE = 2;  CODE_REVERT_ACTION_TYPE_DELETE = 3;}
-enum ClaudeCodeAgentType {  CLAUDE_CODE_AGENT_TYPE_UNSPECIFIED = 0;  CLAUDE_CODE_AGENT_TYPE_USER = 1;  CLAUDE_CODE_AGENT_TYPE_PROJECT = 2;}
-enum CustomizationFileType {  CUSTOMIZATION_FILE_TYPE_UNSPECIFIED = 0;  CUSTOMIZATION_FILE_TYPE_RULES = 1;  CUSTOMIZATION_FILE_TYPE_WORKFLOWS = 2;  CUSTOMIZATION_FILE_TYPE_GLOBAL_WORKFLOWS = 3;}
+enum ResolveWorktreeChangesMode {  RESOLVE_WORKTREE_CHANGES_MODE_UNSPECIFIED = 0;  RESOLVE_WORKTREE_CHANGES_MODE_MERGE = 1;  RESOLVE_WORKTREE_CHANGES_MODE_STASH = 2;}
+enum CustomizationFileType {  CUSTOMIZATION_FILE_TYPE_UNSPECIFIED = 0;  CUSTOMIZATION_FILE_TYPE_RULES = 1;  CUSTOMIZATION_FILE_TYPE_WORKFLOWS = 2;  CUSTOMIZATION_FILE_TYPE_GLOBAL_WORKFLOWS = 3;  CUSTOMIZATION_FILE_TYPE_SKILLS = 4;  CUSTOMIZATION_FILE_TYPE_GLOBAL_SKILLS = 5;}
+enum EditSource {  EDIT_SOURCE_UNSPECIFIED = 0;  EDIT_SOURCE_USER_TYPED = 1;  EDIT_SOURCE_USER_PASTED = 2;  EDIT_SOURCE_USER_UNDO = 3;  EDIT_SOURCE_USER_REDO = 4;  EDIT_SOURCE_USER_CUT = 5;  EDIT_SOURCE_USER_DRAG_DROP = 6;  EDIT_SOURCE_USER_TAB = 7;  EDIT_SOURCE_USER_REFACTORING = 8;  EDIT_SOURCE_USER_FORMATTING = 9;  EDIT_SOURCE_CASCADE_GENERATED = 10;  EDIT_SOURCE_DISK_CHANGE = 11;  EDIT_SOURCE_USER_OTHER = 12;}
 service LanguageServerService {
   rpc GetCompletions(exa.language_server_pb.GetCompletionsRequest) returns (exa.language_server_pb.GetCompletionsResponse);
   rpc AcceptCompletion(exa.language_server_pb.AcceptCompletionRequest) returns (exa.language_server_pb.AcceptCompletionResponse);
@@ -1385,22 +1520,23 @@ service LanguageServerService {
   rpc GetExternalModel(exa.language_server_pb.GetExternalModelRequest) returns (exa.language_server_pb.GetExternalModelResponse);
   rpc GetAuthToken(exa.language_server_pb.GetAuthTokenRequest) returns (exa.language_server_pb.GetAuthTokenResponse);
   rpc RecordEvent(exa.language_server_pb.RecordEventRequest) returns (exa.language_server_pb.RecordEventResponse);
+  rpc RecordSystemMetrics(exa.language_server_pb.RecordSystemMetricsRequest) returns (exa.language_server_pb.RecordSystemMetricsResponse);
   rpc CancelRequest(exa.language_server_pb.CancelRequestRequest) returns (exa.language_server_pb.CancelRequestResponse);
   rpc EditConfiguration(exa.language_server_pb.EditConfigurationRequest) returns (exa.language_server_pb.EditConfigurationResponse);
   rpc MigrateApiKey(exa.language_server_pb.MigrateApiKeyRequest) returns (exa.language_server_pb.MigrateApiKeyResponse);
   rpc GetPrimaryApiKeyForDevsOnly(exa.language_server_pb.GetPrimaryApiKeyForDevsOnlyRequest) returns (exa.language_server_pb.GetPrimaryApiKeyForDevsOnlyResponse);
-  rpc ClusteredSearch(exa.language_server_pb.ClusteredSearchRequest) returns (exa.language_server_pb.ClusteredSearchResponse);
   rpc WellSupportedLanguages(exa.language_server_pb.WellSupportedLanguagesRequest) returns (exa.language_server_pb.WellSupportedLanguagesResponse);
   rpc ProgressBars(exa.language_server_pb.ProgressBarsRequest) returns (exa.language_server_pb.ProgressBarsResponse);
   rpc RecordSearchDocOpen(exa.language_server_pb.RecordSearchDocOpenRequest) returns (exa.language_server_pb.RecordSearchDocOpenResponse);
   rpc RecordSearchResultsView(exa.language_server_pb.RecordSearchResultsViewRequest) returns (exa.language_server_pb.RecordSearchResultsViewResponse);
-  rpc HandleStreamingCommand(stream exa.language_server_pb.HandleStreamingCommandRequest) returns (exa.language_server_pb.HandleStreamingCommandResponse);
-  rpc HandleStreamingTab(stream exa.language_server_pb.HandleStreamingTabRequest) returns (exa.language_server_pb.HandleStreamingTabResponse);
+  rpc HandleStreamingCommand(exa.language_server_pb.HandleStreamingCommandRequest) returns (stream exa.language_server_pb.HandleStreamingCommandResponse);
+  rpc HandleStreamingTab(exa.language_server_pb.HandleStreamingTabRequest) returns (stream exa.language_server_pb.HandleStreamingTabResponse);
+  rpc HandleStreamingTabV2(exa.language_server_pb.HandleStreamingTabV2Request) returns (exa.language_server_pb.HandleStreamingTabV2Response);
+  rpc HandleStreamingTerminalCommand(exa.language_server_pb.HandleStreamingTerminalCommandRequest) returns (stream exa.language_server_pb.HandleStreamingTerminalCommandResponse);
   rpc UploadRecentCommands(exa.language_server_pb.UploadRecentCommandsRequest) returns (exa.language_server_pb.UploadRecentCommandsResponse);
   rpc GetBrainStatus(exa.language_server_pb.GetBrainStatusRequest) returns (exa.language_server_pb.GetBrainStatusResponse);
   rpc SetPinnedGuideline(exa.language_server_pb.SetPinnedGuidelineRequest) returns (exa.language_server_pb.SetPinnedGuidelineResponse);
   rpc SetPinnedContext(exa.language_server_pb.SetPinnedContextRequest) returns (exa.language_server_pb.SetPinnedContextResponse);
-  rpc GetMcpServerTemplates(exa.language_server_pb.GetMcpServerTemplatesRequest) returns (exa.language_server_pb.GetMcpServerTemplatesResponse);
   rpc AddTrackedWorkspace(exa.language_server_pb.AddTrackedWorkspaceRequest) returns (exa.language_server_pb.AddTrackedWorkspaceResponse);
   rpc RemoveTrackedWorkspace(exa.language_server_pb.RemoveTrackedWorkspaceRequest) returns (exa.language_server_pb.RemoveTrackedWorkspaceResponse);
   rpc StatUri(exa.language_server_pb.StatUriRequest) returns (exa.language_server_pb.StatUriResponse);
@@ -1411,25 +1547,25 @@ service LanguageServerService {
   rpc GetMatchingIndexedRepos(exa.language_server_pb.GetMatchingIndexedReposRequest) returns (exa.language_server_pb.GetMatchingIndexedReposResponse);
   rpc GetMatchingContextScopeItems(exa.language_server_pb.GetMatchingContextScopeItemsRequest) returns (exa.language_server_pb.GetMatchingContextScopeItemsResponse);
   rpc GetSuggestedContextScopeItems(exa.language_server_pb.GetSuggestedContextScopeItemsRequest) returns (exa.language_server_pb.GetSuggestedContextScopeItemsResponse);
-  rpc GetChatMessage(stream exa.chat_pb.GetChatMessageRequest) returns (exa.language_server_pb.GetChatMessageResponse);
-  rpc RawGetChatMessage(stream exa.chat_pb.RawGetChatMessageRequest) returns (exa.language_server_pb.RawGetChatMessageResponse);
-  rpc GetDeepWiki(stream exa.chat_pb.GetDeepWikiRequest) returns (exa.language_server_pb.GetDeepWikiResponse);
+  rpc GetChatMessage(exa.chat_pb.GetChatMessageRequest) returns (stream exa.language_server_pb.GetChatMessageResponse);
+  rpc RawGetChatMessage(exa.chat_pb.RawGetChatMessageRequest) returns (stream exa.language_server_pb.RawGetChatMessageResponse);
+  rpc GetDeepWiki(exa.chat_pb.GetDeepWikiRequest) returns (stream exa.language_server_pb.GetDeepWikiResponse);
+  rpc CheckUserMessageRateLimit(exa.language_server_pb.CheckUserMessageRateLimitRequest) returns (exa.language_server_pb.CheckUserMessageRateLimitResponse);
   rpc GetMessageTokenCount(exa.language_server_pb.GetMessageTokenCountRequest) returns (exa.language_server_pb.GetMessageTokenCountResponse);
   rpc RecordChatFeedback(exa.language_server_pb.RecordChatFeedbackRequest) returns (exa.language_server_pb.RecordChatFeedbackResponse);
   rpc RecordChatPanelSession(exa.language_server_pb.RecordChatPanelSessionRequest) returns (exa.language_server_pb.RecordChatPanelSessionResponse);
+  rpc CheckChatCapacity(exa.language_server_pb.CheckChatCapacityRequest) returns (exa.language_server_pb.CheckChatCapacityResponse);
   rpc ShouldEnableUnleash(exa.language_server_pb.ShouldEnableUnleashRequest) returns (exa.language_server_pb.ShouldEnableUnleashResponse);
   rpc GetWorkspaceEditState(exa.language_server_pb.GetWorkspaceEditStateRequest) returns (exa.language_server_pb.GetWorkspaceEditStateResponse);
   rpc GetRepoInfos(exa.language_server_pb.GetRepoInfosRequest) returns (exa.language_server_pb.GetRepoInfosResponse);
   rpc GetWorkspaceInfos(exa.language_server_pb.GetWorkspaceInfosRequest) returns (exa.language_server_pb.GetWorkspaceInfosResponse);
-  rpc CreateWorktree(exa.language_server_pb.CreateWorktreeRequest) returns (exa.language_server_pb.CreateWorktreeResponse);
   rpc GenerateCommitMessage(exa.language_server_pb.GenerateCommitMessageRequest) returns (exa.language_server_pb.GenerateCommitMessageResponse);
   rpc RecordCommitMessageSave(exa.language_server_pb.RecordCommitMessageSaveRequest) returns (exa.language_server_pb.RecordCommitMessageSaveResponse);
-  rpc UpdatePRForWorktree(exa.language_server_pb.UpdatePRForWorktreeRequest) returns (exa.language_server_pb.UpdatePRForWorktreeResponse);
   rpc SendActionToChatPanel(exa.language_server_pb.SendActionToChatPanelRequest) returns (exa.language_server_pb.SendActionToChatPanelResponse);
   rpc GetUserSettings(exa.language_server_pb.GetUserSettingsRequest) returns (exa.language_server_pb.GetUserSettingsResponse);
   rpc SetUserSettings(exa.language_server_pb.SetUserSettingsRequest) returns (exa.language_server_pb.SetUserSettingsResponse);
+  rpc GetDefaultWebOrigins(exa.language_server_pb.GetDefaultWebOriginsRequest) returns (exa.language_server_pb.GetDefaultWebOriginsResponse);
   rpc GetDebugDiagnostics(exa.language_server_pb.GetDebugDiagnosticsRequest) returns (exa.language_server_pb.GetDebugDiagnosticsResponse);
-  rpc GetUserAnalyticsSummary(exa.language_server_pb.GetUserAnalyticsSummaryRequest) returns (exa.language_server_pb.GetUserAnalyticsSummaryResponse);
   rpc GetUserStatus(exa.language_server_pb.GetUserStatusRequest) returns (exa.language_server_pb.GetUserStatusResponse);
   rpc GetProfileData(exa.language_server_pb.GetProfileDataRequest) returns (exa.language_server_pb.GetProfileDataResponse);
   rpc CaptureCode(exa.language_server_pb.CaptureCodeRequest) returns (exa.language_server_pb.CaptureCodeResponse);
@@ -1439,42 +1575,57 @@ service LanguageServerService {
   rpc GetClassInfos(exa.language_server_pb.GetClassInfosRequest) returns (exa.language_server_pb.GetClassInfosResponse);
   rpc SetupUniversitySandbox(exa.language_server_pb.SetupUniversitySandboxRequest) returns (exa.language_server_pb.SetupUniversitySandboxResponse);
   rpc Exit(exa.language_server_pb.ExitRequest) returns (exa.language_server_pb.ExitResponse);
-  rpc RenderInsertionSideHint(exa.language_server_pb.RenderInsertionSideHintRequest) returns (exa.language_server_pb.RenderInsertionSideHintResponse);
   rpc ResetOnboarding(exa.language_server_pb.ResetOnboardingRequest) returns (exa.language_server_pb.ResetOnboardingResponse);
   rpc SkipOnboarding(exa.language_server_pb.SkipOnboardingRequest) returns (exa.language_server_pb.SkipOnboardingResponse);
   rpc GetUserTrajectoryDebug(exa.language_server_pb.GetUserTrajectoryDebugRequest) returns (exa.language_server_pb.GetUserTrajectoryDebugResponse);
   rpc GetUserTrajectoryDescriptions(exa.language_server_pb.GetUserTrajectoryDescriptionsRequest) returns (exa.language_server_pb.GetUserTrajectoryDescriptionsResponse);
-  rpc StreamUserTrajectoryReactiveUpdates(stream exa.reactive_component_pb.StreamReactiveUpdatesRequest) returns (exa.reactive_component_pb.StreamReactiveUpdatesResponse);
+  rpc StreamUserTrajectoryReactiveUpdates(exa.reactive_component_pb.StreamReactiveUpdatesRequest) returns (stream exa.reactive_component_pb.StreamReactiveUpdatesResponse);
   rpc GetCascadeMemories(exa.language_server_pb.GetCascadeMemoriesRequest) returns (exa.language_server_pb.GetCascadeMemoriesResponse);
   rpc DeleteCascadeMemory(exa.language_server_pb.DeleteCascadeMemoryRequest) returns (exa.language_server_pb.DeleteCascadeMemoryResponse);
   rpc UpdateCascadeMemory(exa.language_server_pb.UpdateCascadeMemoryRequest) returns (exa.language_server_pb.UpdateCascadeMemoryResponse);
   rpc GetUserMemories(exa.language_server_pb.GetUserMemoriesRequest) returns (exa.language_server_pb.GetUserMemoriesResponse);
+  rpc RefreshCustomization(exa.language_server_pb.RefreshCustomizationRequest) returns (exa.language_server_pb.RefreshCustomizationResponse);
   rpc GetConversationTags(exa.language_server_pb.GetConversationTagsRequest) returns (exa.language_server_pb.GetConversationTagsResponse);
   rpc UpdateConversationTags(exa.language_server_pb.UpdateConversationTagsRequest) returns (exa.language_server_pb.UpdateConversationTagsResponse);
   rpc StartCascade(exa.language_server_pb.StartCascadeRequest) returns (exa.language_server_pb.StartCascadeResponse);
   rpc CancelCascadeInvocation(exa.language_server_pb.CancelCascadeInvocationRequest) returns (exa.language_server_pb.CancelCascadeInvocationResponse);
+  rpc CancelCascadeInvocationAndWait(exa.language_server_pb.CancelCascadeInvocationAndWaitRequest) returns (exa.language_server_pb.CancelCascadeInvocationAndWaitResponse);
   rpc CancelCascadeSteps(exa.language_server_pb.CancelCascadeStepsRequest) returns (exa.language_server_pb.CancelCascadeStepsResponse);
   rpc SendUserCascadeMessage(exa.language_server_pb.SendUserCascadeMessageRequest) returns (exa.language_server_pb.SendUserCascadeMessageResponse);
+  rpc BranchCascade(exa.language_server_pb.BranchCascadeRequest) returns (exa.language_server_pb.BranchCascadeResponse);
+  rpc QueueCascadeMessage(exa.language_server_pb.QueueCascadeMessageRequest) returns (exa.language_server_pb.QueueCascadeMessageResponse);
+  rpc InterruptWithQueuedMessage(exa.language_server_pb.InterruptWithQueuedMessageRequest) returns (exa.language_server_pb.InterruptWithQueuedMessageResponse);
+  rpc RemoveFromQueue(exa.language_server_pb.RemoveFromQueueRequest) returns (exa.language_server_pb.RemoveFromQueueResponse);
+  rpc MoveQueuedMessage(exa.language_server_pb.MoveQueuedMessageRequest) returns (exa.language_server_pb.MoveQueuedMessageResponse);
+  rpc SyncExploreAgentRun(exa.language_server_pb.SyncExploreAgentRunRequest) returns (exa.language_server_pb.SyncExploreAgentRunResponse);
   rpc RevertToCascadeStep(exa.language_server_pb.RevertToCascadeStepRequest) returns (exa.language_server_pb.RevertToCascadeStepResponse);
   rpc GetRevertPreview(exa.language_server_pb.GetRevertPreviewRequest) returns (exa.language_server_pb.GetRevertPreviewResponse);
-  rpc UnrevertToCascadeStep(exa.language_server_pb.UnrevertToCascadeStepRequest) returns (exa.language_server_pb.UnrevertToCascadeStepResponse);
-  rpc GetUnrevertPreview(exa.language_server_pb.GetUnrevertPreviewRequest) returns (exa.language_server_pb.GetUnrevertPreviewResponse);
   rpc RecordUserStepSnapshot(exa.language_server_pb.RecordUserStepSnapshotRequest) returns (exa.language_server_pb.RecordUserStepSnapshotResponse);
   rpc GetAllCascadeTrajectories(exa.language_server_pb.GetAllCascadeTrajectoriesRequest) returns (exa.language_server_pb.GetAllCascadeTrajectoriesResponse);
   rpc HandleCascadeUserInteraction(exa.language_server_pb.HandleCascadeUserInteractionRequest) returns (exa.language_server_pb.HandleCascadeUserInteractionResponse);
   rpc AcknowledgeCascadeCodeEdit(exa.language_server_pb.AcknowledgeCascadeCodeEditRequest) returns (exa.language_server_pb.AcknowledgeCascadeCodeEditResponse);
   rpc GetCodeValidationStates(exa.language_server_pb.GetCodeValidationStatesRequest) returns (exa.language_server_pb.GetCodeValidationStatesResponse);
+  rpc ResolveWorktreeChanges(exa.language_server_pb.ResolveWorktreeChangesRequest) returns (exa.language_server_pb.ResolveWorktreeChangesResponse);
   rpc DeleteCascadeTrajectory(exa.language_server_pb.DeleteCascadeTrajectoryRequest) returns (exa.language_server_pb.DeleteCascadeTrajectoryResponse);
   rpc RenameCascadeTrajectory(exa.language_server_pb.RenameCascadeTrajectoryRequest) returns (exa.language_server_pb.RenameCascadeTrajectoryResponse);
   rpc InitializeCascadePanelState(exa.language_server_pb.InitializeCascadePanelStateRequest) returns (exa.language_server_pb.InitializeCascadePanelStateResponse);
-  rpc StreamCascadePanelReactiveUpdates(stream exa.reactive_component_pb.StreamReactiveUpdatesRequest) returns (exa.reactive_component_pb.StreamReactiveUpdatesResponse);
-  rpc StreamCascadeReactiveUpdates(stream exa.reactive_component_pb.StreamReactiveUpdatesRequest) returns (exa.reactive_component_pb.StreamReactiveUpdatesResponse);
-  rpc StreamCascadeSummariesReactiveUpdates(stream exa.reactive_component_pb.StreamReactiveUpdatesRequest) returns (exa.reactive_component_pb.StreamReactiveUpdatesResponse);
+  rpc UpdatePanelStateWithUserStatus(exa.language_server_pb.UpdatePanelStateWithUserStatusRequest) returns (exa.language_server_pb.UpdatePanelStateWithUserStatusResponse);
+  rpc UpdateWorkspaceTrust(exa.language_server_pb.UpdateWorkspaceTrustRequest) returns (exa.language_server_pb.UpdateWorkspaceTrustResponse);
+  rpc SpawnArenaModeMidConversation(exa.language_server_pb.SpawnArenaModeMidConversationRequest) returns (exa.language_server_pb.SpawnArenaModeMidConversationResponse);
+  rpc ConvergeArenaCascades(exa.language_server_pb.ConvergeArenaCascadesRequest) returns (exa.language_server_pb.ConvergeArenaCascadesResponse);
+  rpc StreamCascadePanelReactiveUpdates(exa.reactive_component_pb.StreamReactiveUpdatesRequest) returns (stream exa.reactive_component_pb.StreamReactiveUpdatesResponse);
+  rpc StreamCascadeReactiveUpdates(exa.reactive_component_pb.StreamReactiveUpdatesRequest) returns (stream exa.reactive_component_pb.StreamReactiveUpdatesResponse);
+  rpc StreamCascadeSummariesReactiveUpdates(exa.reactive_component_pb.StreamReactiveUpdatesRequest) returns (stream exa.reactive_component_pb.StreamReactiveUpdatesResponse);
   rpc ForceBackgroundResearchRefresh(exa.language_server_pb.ForceBackgroundResearchRefreshRequest) returns (exa.language_server_pb.ForceBackgroundResearchRefreshResponse);
   rpc ResolveOutstandingSteps(exa.language_server_pb.ResolveOutstandingStepsRequest) returns (exa.language_server_pb.ResolveOutstandingStepsResponse);
   rpc RefreshMcpServers(exa.language_server_pb.RefreshMcpServersRequest) returns (exa.language_server_pb.RefreshMcpServersResponse);
   rpc GetMcpServerStates(exa.language_server_pb.GetMcpServerStatesRequest) returns (exa.language_server_pb.GetMcpServerStatesResponse);
-  rpc StreamTerminalShellCommand(exa.codeium_common_pb.TerminalShellCommandStreamChunk) returns (stream exa.language_server_pb.StreamTerminalShellCommandResponse);
+  rpc GetMcpPrompt(exa.language_server_pb.GetMcpPromptRequest) returns (exa.language_server_pb.GetMcpPromptResponse);
+  rpc SaveMcpServerToConfigFile(exa.language_server_pb.SaveMcpServerToConfigFileRequest) returns (exa.language_server_pb.SaveMcpServerToConfigFileResponse);
+  rpc UpdateMcpServerInConfigFile(exa.language_server_pb.UpdateMcpServerInConfigFileRequest) returns (exa.language_server_pb.UpdateMcpServerInConfigFileResponse);
+  rpc ToggleMcpTool(exa.language_server_pb.ToggleMcpToolRequest) returns (exa.language_server_pb.ToggleMcpToolResponse);
+  rpc DismissCodeMapSuggestion(exa.language_server_pb.DismissCodeMapSuggestionRequest) returns (exa.language_server_pb.DismissCodeMapSuggestionResponse);
+  rpc StreamTerminalShellCommand(stream exa.codeium_common_pb.TerminalShellCommandStreamChunk) returns (exa.language_server_pb.StreamTerminalShellCommandResponse);
   rpc GetWebDocsOptions(exa.language_server_pb.GetWebDocsOptionsRequest) returns (exa.language_server_pb.GetWebDocsOptionsResponse);
   rpc UpdateDevExperiments(exa.language_server_pb.UpdateDevExperimentsRequest) returns (exa.language_server_pb.UpdateDevExperimentsResponse);
   rpc SetBaseExperiments(exa.language_server_pb.SetBaseExperimentsRequest) returns (exa.language_server_pb.SetBaseExperimentsResponse);
@@ -1483,32 +1634,16 @@ service LanguageServerService {
   rpc GetWindsurfJSAppDeployment(exa.language_server_pb.GetWindsurfJSAppDeploymentRequest) returns (exa.language_server_pb.GetWindsurfJSAppDeploymentResponse);
   rpc GetModelStatuses(exa.language_server_pb.GetModelStatusesRequest) returns (exa.language_server_pb.GetModelStatusesResponse);
   rpc UpdateAutoCascadeGithubCredentials(exa.language_server_pb.UpdateAutoCascadeGithubCredentialsRequest) returns (exa.language_server_pb.UpdateAutoCascadeGithubCredentialsResponse);
-  rpc SendUserAutoCascadeMessage(exa.language_server_pb.SendUserAutoCascadeMessageRequest) returns (exa.language_server_pb.SendUserAutoCascadeMessageResponse);
-  rpc DeleteAutoCascadeSession(exa.language_server_pb.DeleteAutoCascadeSessionRequest) returns (exa.language_server_pb.DeleteAutoCascadeSessionResponse);
-  rpc CheckoutAutoCascadeSessionBranch(exa.language_server_pb.CheckoutAutoCascadeSessionBranchRequest) returns (exa.language_server_pb.CheckoutAutoCascadeSessionBranchResponse);
-  rpc DiffAutoCascadeSessionBranch(exa.language_server_pb.DiffAutoCascadeSessionBranchRequest) returns (exa.language_server_pb.DiffAutoCascadeSessionBranchResponse);
-  rpc MergeAutoCascadeSessionBranch(exa.language_server_pb.MergeAutoCascadeSessionBranchRequest) returns (exa.language_server_pb.MergeAutoCascadeSessionBranchResponse);
-  rpc StreamAutoCascadeTrajectoriesReactiveUpdates(stream exa.reactive_component_pb.StreamReactiveUpdatesRequest) returns (exa.reactive_component_pb.StreamReactiveUpdatesResponse);
   rpc GetAllWorkflows(exa.language_server_pb.GetAllWorkflowsRequest) returns (exa.language_server_pb.GetAllWorkflowsResponse);
   rpc CopyBuiltinWorkflowToWorkspace(exa.language_server_pb.CopyBuiltinWorkflowToWorkspaceRequest) returns (exa.language_server_pb.CopyBuiltinWorkflowToWorkspaceResponse);
   rpc GetAllRules(exa.language_server_pb.GetAllRulesRequest) returns (exa.language_server_pb.GetAllRulesResponse);
-  rpc GetAllClaudeCodeAgents(exa.language_server_pb.GetAllClaudeCodeAgentsRequest) returns (exa.language_server_pb.GetAllClaudeCodeAgentsResponse);
-  rpc CreateClaudeCodeAgent(exa.language_server_pb.CreateClaudeCodeAgentRequest) returns (exa.language_server_pb.CreateClaudeCodeAgentResponse);
-  rpc DeleteClaudeCodeAgent(exa.language_server_pb.DeleteClaudeCodeAgentRequest) returns (exa.language_server_pb.DeleteClaudeCodeAgentResponse);
-  rpc GetAllClaudeCodeMemories(exa.language_server_pb.GetAllClaudeCodeMemoriesRequest) returns (exa.language_server_pb.GetAllClaudeCodeMemoriesResponse);
-  rpc CreateClaudeCodeMemories(exa.language_server_pb.CreateClaudeCodeMemoriesRequest) returns (exa.language_server_pb.CreateClaudeCodeMemoriesResponse);
-  rpc DeleteClaudeCodeMemories(exa.language_server_pb.DeleteClaudeCodeMemoriesRequest) returns (exa.language_server_pb.DeleteClaudeCodeMemoriesResponse);
-  rpc GetClaudeCodeSettings(exa.language_server_pb.GetClaudeCodeSettingsRequest) returns (exa.language_server_pb.GetClaudeCodeSettingsResponse);
-  rpc EditClaudeCodeSettings(exa.language_server_pb.EditClaudeCodeSettingsRequest) returns (exa.language_server_pb.EditClaudeCodeSettingsResponse);
-  rpc GetClaudeCodeProjectMcp(exa.language_server_pb.GetClaudeCodeProjectMcpRequest) returns (exa.language_server_pb.GetClaudeCodeProjectMcpResponse);
-  rpc EditClaudeCodeProjectMcp(exa.language_server_pb.EditClaudeCodeProjectMcpRequest) returns (exa.language_server_pb.EditClaudeCodeProjectMcpResponse);
-  rpc ListMcpResources(exa.language_server_pb.ListMcpResourcesRequest) returns (exa.language_server_pb.ListMcpResourcesResponse);
+  rpc GetAllSkills(exa.language_server_pb.GetAllSkillsRequest) returns (exa.language_server_pb.GetAllSkillsResponse);
+  rpc GetAllPlans(exa.language_server_pb.GetAllPlansRequest) returns (exa.language_server_pb.GetAllPlansResponse);
   rpc UpdateEnterpriseExperimentsFromUrl(exa.language_server_pb.UpdateEnterpriseExperimentsFromUrlRequest) returns (exa.language_server_pb.UpdateEnterpriseExperimentsFromUrlResponse);
   rpc ImportFromCursor(exa.language_server_pb.ImportFromCursorRequest) returns (exa.language_server_pb.ImportFromCursorResponse);
   rpc CreateCustomizationFile(exa.language_server_pb.CreateCustomizationFileRequest) returns (exa.language_server_pb.CreateCustomizationFileResponse);
   rpc GetTeamOrganizationalControls(exa.language_server_pb.GetTeamOrganizationalControlsRequest) returns (exa.language_server_pb.GetTeamOrganizationalControlsResponse);
   rpc RecordUserGrep(exa.language_server_pb.RecordUserGrepRequest) returns (exa.language_server_pb.RecordUserGrepResponse);
-  rpc GetGithubPullRequestInfo(exa.language_server_pb.GetGithubPullRequestInfoRequest) returns (exa.language_server_pb.GetGithubPullRequestInfoResponse);
   rpc GetGithubPullRequestSearchInfo(exa.language_server_pb.GetGithubPullRequestSearchInfoRequest) returns (exa.language_server_pb.GetGithubPullRequestSearchInfoResponse);
   rpc CreateTrajectoryShare(exa.language_server_pb.CreateTrajectoryShareRequest) returns (exa.language_server_pb.CreateTrajectoryShareResponse);
   rpc GetKnowledgeBaseItemsForTeam(exa.language_server_pb.GetKnowledgeBaseItemsForTeamRequest) returns (exa.language_server_pb.GetKnowledgeBaseItemsForTeamResponse);
@@ -1522,11 +1657,24 @@ service LanguageServerService {
   rpc GetCascadePluginById(exa.language_server_pb.GetCascadePluginByIdRequest) returns (exa.language_server_pb.GetCascadePluginByIdResponse);
   rpc RecordLints(exa.language_server_pb.RecordLintsRequest) returns (exa.language_server_pb.RecordLintsResponse);
   rpc ReplayGroundTruthTrajectory(exa.language_server_pb.ReplayGroundTruthTrajectoryRequest) returns (exa.language_server_pb.ReplayGroundTruthTrajectoryResponse);
-  rpc RecordInteractiveCascadeFeedback(exa.language_server_pb.RecordInteractiveCascadeFeedbackRequest) returns (exa.language_server_pb.RecordInteractiveCascadeFeedbackResponse);
+  rpc MountCascadeFilesystem(exa.language_server_pb.MountCascadeFilesystemRequest) returns (exa.language_server_pb.MountCascadeFilesystemResponse);
+  rpc UnmountCascadeFilesystem(exa.language_server_pb.UnmountCascadeFilesystemRequest) returns (exa.language_server_pb.UnmountCascadeFilesystemResponse);
   rpc LogCascadeSession(exa.language_server_pb.LogCascadeSessionRequest) returns (exa.language_server_pb.LogCascadeSessionResponse);
-  rpc GetCascadeNuxes(exa.language_server_pb.GetCascadeNuxesRequest) returns (exa.language_server_pb.GetCascadeNuxesResponse);
   rpc GetTranscription(exa.language_server_pb.GetTranscriptionRequest) returns (exa.language_server_pb.GetTranscriptionResponse);
-  rpc GenerateVibeAndReplaceStreaming(stream exa.language_server_pb.GenerateVibeAndReplaceStreamingRequest) returns (exa.language_server_pb.GenerateVibeAndReplaceStreamingResponse);
-  rpc ClaudeCodeMCP(exa.language_server_pb.ClaudeCodeMCPRequest) returns (exa.language_server_pb.ClaudeCodeMCPResponse);
+  rpc GenerateVibeAndReplaceStreaming(exa.language_server_pb.GenerateVibeAndReplaceStreamingRequest) returns (stream exa.language_server_pb.GenerateVibeAndReplaceStreamingResponse);
+  rpc GetCodeMapsForRepos(exa.language_server_pb.GetCodeMapsForReposRequest) returns (exa.language_server_pb.GetCodeMapsForReposResponse);
+  rpc GetCodeMapsForFile(exa.language_server_pb.GetCodeMapsForFileRequest) returns (exa.language_server_pb.GetCodeMapsForFileResponse);
+  rpc GenerateCodeMap(exa.language_server_pb.GenerateCodeMapRequest) returns (stream exa.language_server_pb.GenerateCodeMapResponse);
+  rpc BranchCascadeAndGenerateCodeMap(exa.language_server_pb.BranchCascadeAndGenerateCodeMapRequest) returns (stream exa.language_server_pb.BranchCascadeAndGenerateCodeMapResponse);
+  rpc ShareCodeMap(exa.language_server_pb.ShareCodeMapRequest) returns (exa.language_server_pb.ShareCodeMapResponse);
+  rpc GetSharedCodeMap(exa.language_server_pb.GetSharedCodeMapRequest) returns (exa.language_server_pb.GetSharedCodeMapResponse);
+  rpc GetCodeMapSuggestions(exa.language_server_pb.GetCodeMapSuggestionsRequest) returns (exa.language_server_pb.GetCodeMapSuggestionsResponse);
+  rpc UpdateCodeMapMetadata(exa.language_server_pb.UpdateCodeMapMetadataRequest) returns (exa.language_server_pb.UpdateCodeMapMetadataResponse);
+  rpc SaveCodeMapFromJson(exa.language_server_pb.SaveCodeMapFromJsonRequest) returns (exa.language_server_pb.SaveCodeMapFromJsonResponse);
+  rpc CheckBugs(exa.language_server_pb.CheckBugsRequest) returns (exa.language_server_pb.CheckBugsResponse);
+  rpc GetLifeguardConfig(exa.language_server_pb.GetLifeguardConfigRequest) returns (exa.language_server_pb.GetLifeguardConfigResponse);
+  rpc SubmitBugReport(exa.language_server_pb.SubmitBugReportRequest) returns (exa.language_server_pb.SubmitBugReportResponse);
+  rpc OnEdit(exa.language_server_pb.OnEditRequest) returns (exa.language_server_pb.OnEditResponse);
+  rpc GetSystemPromptAndTools(exa.language_server_pb.GetSystemPromptAndToolsRequest) returns (exa.language_server_pb.GetSystemPromptAndToolsResponse);
 }
 

--- a/protos/exa.reactive_component_pb.proto
+++ b/protos/exa.reactive_component_pb.proto
@@ -53,5 +53,6 @@ message MessageDiff {  repeated exa.reactive_component_pb.FieldDiff field_diffs 
 
 message StreamReactiveUpdatesResponse {  uint64 version = 1;
   exa.reactive_component_pb.MessageDiff diff = 2;
+  bytes full_state = 3;
 }
 


### PR DESCRIPTION
Looks like there have been some structural changes to windsurf that move the chat panel into the main 40+mb bundle for their vscodium fork.

I let GPT 5.2 codex bang its head against a wall to get a working strip_bundle.js and then cleaned up the functional code a bit. I expect it to be fragile, but it'll probably work for at least a few future versions.

```
44M Jan 29 22:51 workbench.desktop.main.js
1.4M Jan 30 00:08 workbench.desktop.main.protos.js
```

Key Changes:
- Update DECOMPILE.md with new workflow and legacy fallback instructions
- Modify decompile_protos.js to auto-detect and load correct bundle file
- Update .gitignore for new bundle/derivative files
- Regenerate protos from Windsurf 1.13.14 (Extension 1.48.2)

P.S. Thanks a bunch for the rough protobuf gen code, as someone newer to the protobuf ecosystem, that would have taken me a painful amount of time to create from js objects. (likely would have tried an AST transform and wasted a bunch of time)
